### PR TITLE
Fix json tags on kubeadm types

### DIFF
--- a/config/crd/bases/kubeadm.bootstrap.cluster.sigs.k8s.io_kubeadmbootstrapconfigs.yaml
+++ b/config/crd/bases/kubeadm.bootstrap.cluster.sigs.k8s.io_kubeadmbootstrapconfigs.yaml
@@ -758,14 +758,6 @@ spec:
                         description: Token is used for establishing bidirectional
                           trust between nodes and control-planes. Used for joining
                           nodes in the cluster.
-                        properties:
-                          id:
-                            type: string
-                          secret:
-                            type: string
-                        required:
-                        - id
-                        - secret
                         type: object
                       ttl:
                         description: TTL defines the time to live for this token.

--- a/kubeadm/v1beta1/bootstraptokenstring.go
+++ b/kubeadm/v1beta1/bootstraptokenstring.go
@@ -31,8 +31,8 @@ import (
 // of view and as an authentication method for the node in the bootstrap phase of
 // "kubeadm join". This token is and should be short-lived
 type BootstrapTokenString struct {
-	ID     string `json:"id"`
-	Secret string `json:"secret"`
+	ID     string `json:"-"`
+	Secret string `json:"-"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/kubeadm/v1beta2/bootstraptokenstring.go
+++ b/kubeadm/v1beta2/bootstraptokenstring.go
@@ -31,8 +31,8 @@ import (
 // of view and as an authentication method for the node in the bootstrap phase of
 // "kubeadm join". This token is and should be short-lived
 type BootstrapTokenString struct {
-	ID     string `json:"id"`
-	Secret string `json:"secret"`
+	ID     string `json:"-"`
+	Secret string `json:"-"`
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR fixes the json tags in the bootstrap token. They should be ignored by json.Marshal and use the custom Unmarshal/Marshal functions instead.

**Special notes for your reviewer**:
Please see https://github.com/kubernetes/kubernetes/pull/80050

**Release note**:
```release-note
NONE
```