### PR TITLE
Implement main.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
 	kubectl apply -f config/crd/bases
-	kustomize build config/default | kubectl apply -f -
+	kubectl kustomize config/default | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
 github.com/Azure/go-autorest/autorest v0.2.0/go.mod h1:AKyIcETwSUFxIcs/Wnq/C+kwCtlEYGUVd7FPNb2slmg=

--- a/main.go
+++ b/main.go
@@ -19,9 +19,55 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
+	"flag"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/controllers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
 )
 
+var (
+	myscheme = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	_ = scheme.AddToScheme(myscheme)
+	_ = v1alpha1.AddToScheme(myscheme)
+	// +kubebuilder:scaffold:scheme
+}
+
 func main() {
-	fmt.Println("hello world")
+	var metricsAddr string
+	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.Parse()
+
+	ctrl.SetLogger(klogr.New())
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{Scheme: myscheme, MetricsBindAddress: metricsAddr})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := (&controllers.KubeadmBootstrapConfigReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("reconciler"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "reconciler")
+		os.Exit(1)
+	}
+	// +kubebuilder:scaffold:builder
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
* Remove dependency on kustomize (use kubectl kustomize instead)

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR implements main straight out of Kubebuilder book except for our types.

**Special notes for your reviewer**:
This removes the dependency on kustomize when installing the manager and instead uses `kubectl kustomize`.

**Release note**:
```release-note
NONE
```

/assign @fabriziopandini 
/cc @amy @neolit123 @vincepri 