### PR TITLE
only print failed verfiy outputs

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -26,75 +26,78 @@ cd "${REPO_PATH}"
 failure() {
     if [[ "${1}" = 1 ]]; then
         res=1
-        echo "${2} failed"
+        failed+=("${2}")
+        outputs+=("${3}")
     fi
 }
 
 # exit code, if a script fails we'll set this to 1
 res=0
+failed=()
+outputs=()
 
 # run all verify scripts, optionally skipping any of them
 
 if [[ "${VERIFY_WHITESPACE:-true}" == "true" ]]; then
   echo "[*] Verifying whitespace..."
-  hack/verify-whitespace.sh
-  failure $? "verify-whitespace.sh"
+  out=$(hack/verify-whitespace.sh 2>&1)
+  failure $? "verify-whitespace.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_SPELLING:-true}" == "true" ]]; then
   echo "[*] Verifying spelling..."
-  hack/verify-spelling.sh
-  failure $? "verify-spelling.sh"
+  out=$(hack/verify-spelling.sh 2>&1)
+  failure $? "verify-spelling.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_BOILERPLATE:-true}" == "true" ]]; then
   echo "[*] Verifying boilerplate..."
-  hack/verify-boilerplate.sh
-  failure $? "verify-boilerplate.sh"
+  out=$(hack/verify-boilerplate.sh 2>&1)
+  failure $? "verify-boilerplate.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_GOFMT:-true}" == "true" ]]; then
   echo "[*] Verifying gofmt..."
-  hack/verify-gofmt.sh
-  failure $? "verify-gofmt.sh"
+  out=$(hack/verify-gofmt.sh 2>&1)
+  failure $? "verify-gofmt.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_GOLINT:-true}" == "true" ]]; then
   echo "[*] Verifying golint..."
-  hack/verify-golint.sh
-  failure $? "verify-golint.sh"
+  out=$(hack/verify-golint.sh 2>&1)
+  failure $? "verify-golint.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_GOVET:-true}" == "true" ]]; then
   echo "[*] Verifying govet..."
-  hack/verify-govet.sh
-  failure $? "verify-govet.sh"
+  out=$(hack/verify-govet.sh 2>&1)
+  failure $? "verify-govet.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_DEPS:-true}" == "true" ]]; then
   echo "[*] Verifying deps..."
-  hack/verify-deps.sh
-  failure $? "verify-deps.sh"
+  out=$(hack/verify-deps.sh 2>&1)
+  failure $? "verify-deps.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_GOTEST:-true}" == "true" ]]; then
   echo "[*] Verifying gotest..."
-  hack/verify-gotest.sh
-  failure $? "verify-gotest.sh"
+  out=$(hack/verify-gotest.sh 2>&1)
+  failure $? "verify-gotest.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
 if [[ "${VERIFY_BUILD:-true}" == "true" ]]; then
   echo "[*] Verifying build..."
-  hack/verify-build.sh
-  failure $? "verify-build.sh"
+  out=$(hack/verify-build.sh 2>&1)
+  failure $? "verify-build.sh" "${out}"
   cd "${REPO_PATH}"
 fi
 
@@ -104,6 +107,11 @@ if [[ "${res}" = 0 ]]; then
   echo "All verify checks passed, congrats!"
 else
   echo ""
-  echo "One or more verify checks failed! See output above..."
+  echo "Some of the verify scripts failed:"
+  for i in "${!failed[@]}"; do
+      echo "- ${failed[$i]}:"
+      echo "${outputs[$i]}"
+      echo
+  done
 fi
 exit "${res}"


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR makes the output of hack/verify-all.sh more useful by only showing the output of the failed files.

Related to #35 

```release-note
NONE
```

/assign @neolit123 

<details><summary>The output</summary>

```

chuckh-a02:cluster-api-bootstrap-provider-kubeadm cha$ ./hack/verify-all.sh 
[*] Verifying whitespace...
[*] Verifying spelling...
[*] Verifying boilerplate...
[*] Verifying gofmt...
[*] Verifying golint...
[*] Verifying govet...
[*] Verifying deps...
[*] Verifying gotest...
[*] Verifying build...

Some of the verify scripts failed:
- verify-boilerplate.sh:
skipping ".github/ISSUE_TEMPLATE/bug_report.md": unsupported file type
skipping ".github/ISSUE_TEMPLATE/feature_request.md": unsupported file type
skipping ".github/PULL_REQUEST_TEMPLATE.md": unsupported file type
skipping ".gitignore": unsupported file type
skipping "CONTRIBUTING.md": unsupported file type
skipping "Dockerfile": unsupported file type
skipping "LICENSE": unsupported file type
skipping "Makefile": unsupported file type
skipping "OWNERS": unsupported file type
skipping "OWNERS_ALIASES": unsupported file type
skipping "PROJECT": unsupported file type
skipping "README.md": unsupported file type
skipping "RELEASE.md": unsupported file type
skipping "SECURITY_CONTACTS": unsupported file type
skipping "code-of-conduct.md": unsupported file type
skipping "config/certmanager/certificate.yaml": unsupported file type
skipping "config/certmanager/kustomization.yaml": unsupported file type
skipping "config/certmanager/kustomizeconfig.yaml": unsupported file type
skipping "config/crd/bases/kubeadm.bootstrap.cluster.sigs.k8s.io_kubeadmbootstrapconfigs.yaml": unsupported file type
skipping "config/crd/kustomization.yaml": unsupported file type
skipping "config/crd/kustomizeconfig.yaml": unsupported file type
skipping "config/crd/patches/cainjection_in_kubeadmbootstrapconfigs.yaml": unsupported file type
skipping "config/crd/patches/webhook_in_kubeadmbootstrapconfigs.yaml": unsupported file type
skipping "config/default/kustomization.yaml": unsupported file type
skipping "config/default/manager_auth_proxy_patch.yaml": unsupported file type
skipping "config/default/manager_image_patch.yaml": unsupported file type
skipping "config/default/manager_prometheus_metrics_patch.yaml": unsupported file type
skipping "config/default/manager_webhook_patch.yaml": unsupported file type
skipping "config/default/webhookcainjection_patch.yaml": unsupported file type
skipping "config/manager/kustomization.yaml": unsupported file type
skipping "config/manager/manager.yaml": unsupported file type
skipping "config/rbac/auth_proxy_role.yaml": unsupported file type
skipping "config/rbac/auth_proxy_role_binding.yaml": unsupported file type
skipping "config/rbac/auth_proxy_service.yaml": unsupported file type
skipping "config/rbac/kustomization.yaml": unsupported file type
skipping "config/rbac/leader_election_role.yaml": unsupported file type
skipping "config/rbac/leader_election_role_binding.yaml": unsupported file type
skipping "config/rbac/role.yaml": unsupported file type
skipping "config/rbac/role_binding.yaml": unsupported file type
skipping "config/samples/kubeadm_v1alpha1_kubeadmbootstrapconfig.yaml": unsupported file type
skipping "config/webhook/kustomization.yaml": unsupported file type
skipping "config/webhook/kustomizeconfig.yaml": unsupported file type
skipping "config/webhook/manifests.yaml": unsupported file type
skipping "config/webhook/service.yaml": unsupported file type
error validating "controllers/control_plane_init_locker.go": boilerplate line 2 does not match
expected: ""
got: "Licensed under the Apache License, Version 2.0 (the \"License\");"
error validating "controllers/control_plane_init_locker_test.go": boilerplate line 2 does not match
expected: ""
got: "Licensed under the Apache License, Version 2.0 (the \"License\");"
skipping "go.mod": unsupported file type
skipping "go.sum": unsupported file type
skipping "hack/boilerplate.go.txt": unsupported file type
skipping "kubeadm/README.md": unsupported file type
exit status 1

- verify-golint.sh:
Cloning http://github.com/golang/lint in /var/folders/2p/tnmjv6hn1ws2lv1bdfh8v6zr0000gq/T/tmp.GeOQ62zM...
Building golint...
Running golint...
api/v1alpha1/kubeadmbootstrapconfig_types.go:35:6: exported type KubeadmBootstrapConfigSpec should have comment or be unexported
Found 1 lint suggestions; failing.
cloudinit/cloudinit.go:32:6: exported type BaseUserData should have comment or be unexported
Found 1 lint suggestions; failing.
cloudinit/controlplane_certs.go:21:6: exported type Certificates should have comment or be unexported
Found 1 lint suggestions; failing.
Cleaning up...

```
</details>