### PR TITLE
Use a ready/bool instead of phase

### DIFF
--- a/api/v1alpha1/kubeadmbootstrapconfig_types.go
+++ b/api/v1alpha1/kubeadmbootstrapconfig_types.go
@@ -21,15 +21,6 @@ import (
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
 )
 
-// Phase defines KubeadmBootstrapConfig phases
-type Phase string
-
-// Ready defines the KubeadmBootstrapConfig Ready Phase
-const (
-	// Ready indicates the config is ready to be used by a Machine.
-	Ready Phase = "Ready"
-)
-
 // KubeadmBootstrapConfigSpec defines the desired state of KubeadmBootstrapConfig
 type KubeadmBootstrapConfigSpec struct {
 	ClusterConfiguration kubeadmv1beta1.ClusterConfiguration `json:"clusterConfiguration"`
@@ -39,8 +30,8 @@ type KubeadmBootstrapConfigSpec struct {
 
 // KubeadmBootstrapConfigStatus defines the observed state of KubeadmBootstrapConfig
 type KubeadmBootstrapConfigStatus struct {
-	// Phase is the state of the KubeadmBootstrapConfig object
-	Phase Phase `json:"phase"`
+	// Ready indicates the BootstrapData field is ready to be consumed
+	Ready bool `json:"phase,omitempty"`
 
 	// BootstrapData will be a cloud-init script for now
 	// +optional

--- a/config/crd/bases/kubeadm.bootstrap.cluster.sigs.k8s.io_kubeadmbootstrapconfigs.yaml
+++ b/config/crd/bases/kubeadm.bootstrap.cluster.sigs.k8s.io_kubeadmbootstrapconfigs.yaml
@@ -1059,10 +1059,9 @@ spec:
               format: byte
               type: string
             phase:
-              description: Phase is the state of the KubeadmBootstrapConfig object
-              type: string
-          required:
-          - phase
+              description: Ready indicates the BootstrapData field is ready to be
+                consumed
+              type: boolean
           type: object
       type: object
   versions:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190704094733-8f6ac2502e51
 	k8s.io/client-go v11.0.1-0.20190704100234-640d9f240853+incompatible
 	k8s.io/cluster-bootstrap v0.0.0-20190703212826-5ad085674a4f
+	k8s.io/klog v0.3.1
 	k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a // indirect
 	sigs.k8s.io/cluster-api v0.0.0-20190711133056-09e491e49d7c
 	sigs.k8s.io/controller-runtime v0.2.0-beta.4


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR uses the new Ready bool field instead of the old Phase enum/string field.

/cc @amy 
/assign @vincepri 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #37 

**Special notes for your reviewer**:
There was a go.mod change that snuck in as well. I can pull it out if there are concerns. It is related to #31 

**Release note**:
```release-note
NONE
```
