### PR TITLE
Fix for kustomize v3.0

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment next line. 'WEBHOOK' components are required.
 #- ../certmanager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This patch fixes deprecated and invalid YAML in the kustomize.yaml file.

Patches got replaced. Please see: https://github.com/kubernetes-sigs/kubebuilder/pull/872

