### PR TITLE
Enable GOPROXY default in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# TODO: use go env GOPROXY here
-# Allow users to override during make or default if unset
+# Use GOPROXY environment variable if set
+GOPROXY := $(shell go env GOPROXY)
 GOPROXY ?= https://proxy.golang.org
 export GOPROXY
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the default GOPROXY to use existing environment variables

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64 