### PR TITLE
Fix up image restart process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ COPY kubeadm/ kubeadm/
 
 # Allow containerd to restart pods by calling /restart.sh (mostly for tilt + fast dev cycles)
 # TODO: Remove this on prod and use a multi-stage build
-COPY third_party/forked/rerun-process-wrapper/start.sh /start.sh
-COPY third_party/forked/rerun-process-wrapper/restart.sh /restart.sh
+COPY third_party/forked/rerun-process-wrapper/start.sh .
+COPY third_party/forked/rerun-process-wrapper/restart.sh .
 
 # Build and run
 RUN go install -v .
 RUN mv /go/bin/cluster-api-bootstrap-provider-kubeadm /manager
-ENTRYPOINT ["/start.sh", "/manager"]
+ENTRYPOINT ["./start.sh", "/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,9 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --enable-leader-election
         image: controller:latest
         imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR allows the container to restart properly. The yaml was overriding the container ENTRYPOINT which I did not want to have happen.

I'm not sure if this is best practice or if I should rewrite the command in the yaml or what. This seemed as good an option as any so I went with it. 

If you have strong opinions or Know About This please leave a comment

```release-note
NONE
```