### PR TITLE
Reconciler loop

### DIFF
--- a/cloudinit/controlplane_join.go
+++ b/cloudinit/controlplane_join.go
@@ -46,6 +46,11 @@ type ControlPlaneJoinInput struct {
 // NewJoinControlPlane returns the user data string to be used on a new control plane instance.
 func NewJoinControlPlane(input *ControlPlaneJoinInput) ([]byte, error) {
 	input.Header = cloudConfigHeader
+	if err := input.Certificates.validate(); err != nil {
+		return nil, errors.Wrapf(err, "ControlPlaneInput is invalid")
+	}
+
+	input.WriteFiles = certificatesToFiles(input.Certificates)
 	input.WriteFiles = append(input.WriteFiles, input.AdditionalFiles...)
 	userData, err := generate("JoinControlplane", controlPlaneJoinCloudInit, input)
 	if err != nil {

--- a/cloudinit/controlplane_join.go
+++ b/cloudinit/controlplane_join.go
@@ -39,19 +39,13 @@ type ControlPlaneJoinInput struct {
 	BaseUserData
 	Certificates
 
-	BootstrapToken      string
-	ControlPlaneAddress string
-	JoinConfiguration   string
+	BootstrapToken    string
+	JoinConfiguration string
 }
 
 // NewJoinControlPlane returns the user data string to be used on a new control plane instance.
 func NewJoinControlPlane(input *ControlPlaneJoinInput) ([]byte, error) {
 	input.Header = cloudConfigHeader
-	if err := input.Certificates.validate(); err != nil {
-		return nil, errors.Wrapf(err, "ControlPlaneInput is invalid")
-	}
-
-	input.WriteFiles = certificatesToFiles(input.Certificates)
 	input.WriteFiles = append(input.WriteFiles, input.AdditionalFiles...)
 	userData, err := generate("JoinControlplane", controlPlaneJoinCloudInit, input)
 	if err != nil {

--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -26,22 +26,24 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeadmv1alpha2 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
-	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/cloudinit"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
 	"sigs.k8s.io/cluster-api/pkg/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cabpkv1alpha2 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
+	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/cloudinit"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
 )
 
 var (
-	machineKind = v1alpha2.SchemeGroupVersion.WithKind("Machine")
+	machineKind = capiv1alpha2.SchemeGroupVersion.WithKind("Machine")
 )
 
 const (
 	// InfrastructureReadyAnnotationKey identifies when the infrastructure is ready for use such as joining new nodes.
 	// TODO move this into cluster-api to be imported by providers
-	InfrastructureReadyAnnotationKey = "cluster.x-k8s.io/infrastructure-ready"
+	ControlPlaneReadyAnnotationKey = "cluster.x-k8s.io/control-plane-ready"
 )
 
 // KubeadmConfigReconciler reconciles a KubeadmConfig object
@@ -59,7 +61,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	ctx := context.Background()
 	log := r.Log.WithValues("kubeadmconfig", req.NamespacedName)
 
-	config := kubeadmv1alpha2.KubeadmConfig{}
+	config := cabpkv1alpha2.KubeadmConfig{}
 	if err := r.Get(ctx, req.NamespacedName, &config); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -75,6 +77,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// Find the owner reference
+	// The cluster-api machine controller set this value.
 	var machineRef *v1.OwnerReference
 	for _, ref := range config.OwnerReferences {
 		if ref.Kind == machineKind.Kind && ref.APIVersion == machineKind.GroupVersion().String() {
@@ -88,7 +91,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// Get the machine
-	machine := &v1alpha2.Machine{}
+	machine := &capiv1alpha2.Machine{}
 	machineKey := client.ObjectKey{
 		Namespace: req.Namespace,
 		Name:      machineRef.Name,
@@ -104,41 +107,107 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return ctrl.Result{}, nil
 	}
 
-	if machine.Labels[v1alpha2.MachineClusterLabelName] == "" {
+	if machine.Labels[capiv1alpha2.MachineClusterLabelName] == "" {
 		return ctrl.Result{}, errors.New("machine has no associated cluster")
 	}
 
 	// Get the cluster
-	cluster := &v1alpha2.Cluster{}
+	cluster := &capiv1alpha2.Cluster{}
 	clusterKey := client.ObjectKey{
 		Namespace: req.Namespace,
-		Name:      machine.Labels[v1alpha2.MachineClusterLabelName],
+		Name:      machine.Labels[capiv1alpha2.MachineClusterLabelName],
 	}
 	if err := r.Get(ctx, clusterKey, cluster); err != nil {
 		log.Error(err, "failed to get cluster")
 		return ctrl.Result{}, err
 	}
 
+	// Check for infrastructure ready. If it's not ready then we will requeue the machine until it is.
+	// The cluster-api machine controller set this value.
+	if cluster.Status.InfrastructureReady != true {
+		log.Info("Infrastructure is not ready, requeing until ready.")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	// Store Config's state, pre-modifications, to allow patching
 	patchConfig := client.MergeFrom(config.DeepCopy())
 
-	// if the machine has cluster and or init defined on it then generate the init regular join
-	if config.Spec.InitConfiguration != nil && config.Spec.ClusterConfiguration != nil {
-		// get both of these to strings to pass to the cloud init control plane generator
+	// Check for control plane ready. If it's not ready then we will requeue the machine until it is.
+	// The cluster-api machine controller set this value.
+	if cluster.Annotations[ControlPlaneReadyAnnotationKey] != "true" {
+		// if it's NOT a control plane machine, requeue
+		if !util.IsControlPlaneMachine(machine) {
+			log.Info("Control plane is not ready, requeing worker nodes until ready.")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+
+		// if the machine has not ClusterConfiguration and InitConfiguration, requeue
+		if config.Spec.InitConfiguration == nil && config.Spec.ClusterConfiguration == nil {
+			log.Info("Control plane is not ready, requeing joining control planes until ready.")
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+
+		//TODO(fp) use init lock so only the first machine configured as control plane get processed, everything else gets requeued
+
+		// otherwise it is a init control plane
+		// Nb. in this case JoinConfiguration should not be defined by users, but in case of misconfigurations, CAPBK simply ignore it
+
+		log.Info("Creating BootstrapData for the init control plane")
+
+		// get both of ClusterConfiguration and InitConfiguration strings to pass to the cloud init control plane generator
+		// kubeadm allows one this values to be empty; cabpk replace missing values with an empty config, so the cloud init generation
+		// should not handle special cases.
+
+		if config.Spec.InitConfiguration == nil {
+			config.Spec.InitConfiguration = &kubeadmv1beta1.InitConfiguration{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "kubeadm.k8s.io/v1beta1",
+					Kind:       "InitConfiguration",
+				},
+			}
+		}
 		initdata, err := json.Marshal(config.Spec.InitConfiguration)
 		if err != nil {
 			log.Error(err, "failed to marshal init configuration")
 			return ctrl.Result{}, err
 		}
+
+		if config.Spec.ClusterConfiguration == nil {
+			config.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "kubeadm.k8s.io/v1beta1",
+					Kind:       "ClusterConfiguration",
+				},
+			}
+		}
+		// If there is a control plane endpoint defined at cluster in cluster status, use it as a control plane endpoint for the K8s cluster
+		if len(cluster.Status.APIEndpoints) > 0 {
+			config.Spec.ClusterConfiguration.ControlPlaneEndpoint = fmt.Sprintf("https://%s:%d", cluster.Status.APIEndpoints[0].Host, cluster.Status.APIEndpoints[0].Port)
+		}
+
 		clusterdata, err := json.Marshal(config.Spec.ClusterConfiguration)
 		if err != nil {
 			log.Error(err, "failed to marshal cluster configuration")
 			return ctrl.Result{}, err
 		}
 
+		//TODO(fp) check what is the expected flow for certificates
+		certificates, _ := NewCertificates()
+
 		cloudInitData, err := cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInput{
+			//TODO(fp) if defined, cluster.Status.APIEndpoints[0] should override ClusterConfiguration.ControlPlaneEndpoint
 			InitConfiguration:    string(initdata),
 			ClusterConfiguration: string(clusterdata),
+			Certificates: cloudinit.Certificates{
+				CACert:           string(certificates.ClusterCA.Cert),
+				CAKey:            string(certificates.ClusterCA.Key),
+				EtcdCACert:       string(certificates.EtcdCA.Cert),
+				EtcdCAKey:        string(certificates.EtcdCA.Key),
+				FrontProxyCACert: string(certificates.FrontProxyCA.Cert),
+				FrontProxyCAKey:  string(certificates.FrontProxyCA.Key),
+				SaCert:           string(certificates.ServiceAccount.Cert),
+				SaKey:            string(certificates.ServiceAccount.Key),
+			},
 		})
 		if err != nil {
 			log.Error(err, "failed to generate cloud init for bootstrap control plane")
@@ -148,32 +217,51 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		config.Status.BootstrapData = cloudInitData
 		config.Status.Ready = true
 
-		if err := r.Update(ctx, &config); err != nil {
-			log.Error(err, "failed to update config")
+		if err := r.patchConfig(ctx, &config, patchConfig); err != nil {
+			log.Error(err, "failed to patch config")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
-	}
+		log.Info("KubeadmConfig updated with BootstrapData for kubeadm init; Status.Ready=true")
 
-	// Requeue until the machine is ready
-	if !cluster.Status.InfrastructureReady {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return ctrl.Result{}, nil
+
 	}
 
 	// Every other case it's a join scenario
+	// Nb. in this case ClusterConfiguration and JoinConfiguration should not be defined by users, but in case of misconfigurations, CAPBK simply ignore them
+
+	if config.Spec.JoinConfiguration == nil {
+		return ctrl.Result{}, errors.New("Control plane already exists for the cluster, only KubeadmConfig objects with JoinConfiguration are allowed")
+	}
+
+	if len(cluster.Status.APIEndpoints) == 0 {
+		return ctrl.Result{}, errors.New("Control plane already exists for the cluster but cluster.Status.APIEndpoints are not set")
+	}
+
+	// Injects the controlplane endpoint address
+	// NB. this assumes nodes using token discovery
+	if config.Spec.JoinConfiguration.Discovery.BootstrapToken == nil {
+		config.Spec.JoinConfiguration.Discovery.BootstrapToken = &kubeadmv1beta1.BootstrapTokenDiscovery{}
+	}
+
+	config.Spec.JoinConfiguration.Discovery.BootstrapToken.APIServerEndpoint = fmt.Sprintf("https://%s:%d", cluster.Status.APIEndpoints[0].Host, cluster.Status.APIEndpoints[0].Port)
+
 	joinBytes, err := json.Marshal(config.Spec.JoinConfiguration)
 	if err != nil {
 		log.Error(err, "failed to marshal join configuration")
 		return ctrl.Result{}, err
 	}
 
+	//TODO(fp) remove init lock
+
 	// it's a control plane join
 	if util.IsControlPlaneMachine(machine) {
-		// TODO return a sensible error if join config is not specified (implies empty configuration)
+		if config.Spec.JoinConfiguration.ControlPlane == nil {
+			return ctrl.Result{}, errors.New("Machine is a ControlPlane, but JoinConfiguration.ControlPlane is not set in the KubeadmConfig object")
+		}
+
 		joinData, err := cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
-			// TODO do a len check or something here
-			ControlPlaneAddress: fmt.Sprintf("https://%s:%d", cluster.Status.APIEndpoints[0].Host, cluster.Status.APIEndpoints[0].Port),
-			JoinConfiguration:   string(joinBytes),
+			JoinConfiguration: string(joinBytes),
 		})
 		if err != nil {
 			log.Error(err, "failed to create a control plane join configuration")
@@ -199,19 +287,8 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	config.Status.BootstrapData = joinData
 	config.Status.Ready = true
 
-	// TODO(ncdc): remove this once we've updated to a version of controller-runtime with
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/526.
-	gvk := config.GroupVersionKind()
-	if err := r.Patch(ctx, &config, patchConfig); err != nil {
-		log.Error(err, "failed to update config")
-		return ctrl.Result{}, err
-	}
-
-	// TODO(ncdc): remove this once we've updated to a version of controller-runtime with
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/526.
-	config.SetGroupVersionKind(gvk)
-	if err := r.Status().Patch(ctx, &config, patchConfig); err != nil {
-		log.Error(err, "failed to update config status")
+	if err := r.patchConfig(ctx, &config, patchConfig); err != nil {
+		log.Error(err, "failed to patch config")
 		return ctrl.Result{}, err
 	}
 
@@ -222,6 +299,22 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 // SetupWithManager TODO
 func (r *KubeadmConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&kubeadmv1alpha2.KubeadmConfig{}).
+		For(&cabpkv1alpha2.KubeadmConfig{}).
 		Complete(r)
+}
+
+func (r *KubeadmConfigReconciler) patchConfig(ctx context.Context, config *cabpkv1alpha2.KubeadmConfig, patchConfig client.Patch) error {
+	// TODO(ncdc): remove this once we've updated to a version of controller-runtime with
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/526.
+	gvk := config.GroupVersionKind()
+	if err := r.Patch(ctx, config, patchConfig); err != nil {
+		return err
+	}
+	// TODO(ncdc): remove this once we've updated to a version of controller-runtime with
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/526.
+	config.SetGroupVersionKind(gvk)
+	if err := r.Status().Patch(ctx, config, patchConfig); err != nil {
+		return err
+	}
+	return nil
 }

--- a/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -22,13 +22,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
 	clusterv1alpha2 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
 )
 
 var _ = Describe("KubeadmConfigReconciler", func() {
@@ -36,66 +37,97 @@ var _ = Describe("KubeadmConfigReconciler", func() {
 	AfterEach(func() {})
 
 	Context("Reconcile a KubeadmConfig", func() {
-		It("should successfully run through the reconcile function", func() {
-			cluster := &clusterv1alpha2.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-cluster",
-				},
-				Status: clusterv1alpha2.ClusterStatus{
-					InfrastructureReady: true,
-				},
-			}
-			machine := &clusterv1alpha2.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-machine",
-					Labels: map[string]string{
-						clusterv1alpha2.MachineClusterLabelName: "my-cluster",
-					},
-				},
-				Spec: clusterv1alpha2.MachineSpec{
-					Bootstrap: clusterv1alpha2.Bootstrap{
-						ConfigRef: &v1.ObjectReference{
-							Kind:       "KubeadmConfig",
-							APIVersion: v1alpha2.GroupVersion.String(),
-							Name:       "my-config",
-						},
-					},
-				},
-			}
-			config := &v1alpha2.KubeadmConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "my-config",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "Machine",
-							APIVersion: clusterv1alpha2.SchemeGroupVersion.String(),
-							Name:       "my-machine",
-							UID:        "a uid",
-						},
-					},
-				},
-			}
+		It("should wait until infrastructure is ready", func() {
+			cluster := newCluster("cluster1")
 			Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
+
+			machine := newMachine(cluster, "my-machine")
 			Expect(k8sClient.Create(context.Background(), machine)).To(Succeed())
+
+			config := newKubeadmConfig(machine, "my-machine-config")
 			Expect(k8sClient.Create(context.Background(), config)).To(Succeed())
 
 			reconciler := KubeadmConfigReconciler{
 				Log:    log.ZapLogger(true),
 				Client: k8sClient,
 			}
-			By("Calling reconcile")
+			By("Calling reconcile should requeue")
 			result, err := reconciler.Reconcile(ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "default",
-					Name:      "my-config",
+					Name:      "my-machine-config",
 				},
 			})
 			Expect(err).To(Succeed())
 			Expect(result.Requeue).To(BeFalse())
 			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
 		})
+		It("should process only control plane machines when infrastructure is ready but control plane is not", func() {
+			cluster := newCluster("cluster2")
+			Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
+			cluster.Status.InfrastructureReady = true
+			Expect(k8sClient.Status().Update(context.Background(), cluster)).To(Succeed())
+
+			controlplaneMachine := newMachine(cluster, "control-plane")
+			controlplaneMachine.ObjectMeta.Labels[clusterv1alpha2.MachineControlPlaneLabelName] = "true"
+			Expect(k8sClient.Create(context.Background(), controlplaneMachine)).To(Succeed())
+
+			controlplaneConfig := newKubeadmConfig(controlplaneMachine, "control-plane-config")
+			controlplaneConfig.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{}
+			controlplaneConfig.Spec.InitConfiguration = &kubeadmv1beta1.InitConfiguration{}
+			Expect(k8sClient.Create(context.Background(), controlplaneConfig)).To(Succeed())
+
+			workerMachine := newMachine(cluster, "worker")
+			Expect(k8sClient.Create(context.Background(), workerMachine)).To(Succeed())
+
+			workerConfig := newKubeadmConfig(workerMachine, "worker-config")
+			Expect(k8sClient.Create(context.Background(), workerConfig)).To(Succeed())
+
+			reconciler := KubeadmConfigReconciler{
+				Log:    log.ZapLogger(true),
+				Client: k8sClient,
+			}
+
+			By("Calling reconcile on a config corresponding to worker node should requeue")
+			resultWorker, err := reconciler.Reconcile(ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "worker-config",
+				},
+			})
+			Expect(err).To(Succeed())
+			Expect(resultWorker.Requeue).To(BeFalse())
+			Expect(resultWorker.RequeueAfter).To(Equal(30 * time.Second))
+
+			By("Calling reconcile on a config corresponding to a control plane node should create BootstrapData")
+			resultControlPlane, err := reconciler.Reconcile(ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      "control-plane-config",
+				},
+			})
+			Expect(err).To(Succeed())
+			Expect(resultControlPlane.Requeue).To(BeFalse())
+			Expect(resultControlPlane.RequeueAfter).To(BeZero())
+
+			controlplaneConfigAfter, err := getKubeadmConfig(k8sClient, "control-plane-config")
+			Expect(err).To(Succeed())
+			Expect(controlplaneConfigAfter.Status.Ready).To(BeTrue())
+			Expect(controlplaneConfigAfter.Status.BootstrapData).NotTo(BeEmpty())
+		})
 	})
 })
+
+// test utils
+
+// getKubeadmConfig returns a KubeadmConfig object from the cluster
+func getKubeadmConfig(c client.Client, name string) (*v1alpha2.KubeadmConfig, error) {
+	ctx := context.Background()
+	controlplaneConfigKey := client.ObjectKey{
+		Namespace: "default",
+		Name:      name,
+	}
+	config := &v1alpha2.KubeadmConfig{}
+	err := c.Get(ctx, controlplaneConfigKey, config)
+	return config, err
+}

--- a/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -23,13 +23,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
-	clusterv1alpha2 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
-	kubeadmv1beta1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
 )
 
 var _ = Describe("KubeadmConfigReconciler", func() {
@@ -62,59 +60,69 @@ var _ = Describe("KubeadmConfigReconciler", func() {
 			Expect(result.Requeue).To(BeFalse())
 			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
 		})
-		It("should process only control plane machines when infrastructure is ready but control plane is not", func() {
-			cluster := newCluster("cluster2")
-			Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
-			cluster.Status.InfrastructureReady = true
-			Expect(k8sClient.Status().Update(context.Background(), cluster)).To(Succeed())
+		/*
+				When apimachinery decodes into a typed struct, the decoder strips the TypeMeta from the object;
+				the theory at the time being that because it was a typed object, you knew its API version, group, and kind.
+				if fact this leads to errors with k8sClient, because it loses GVK, and this leads r.Status().Patch to fail
+				with "the server could not find the requested resource (patch kubeadmconfigs.bootstrap.cluster.x-k8s.io control-plane-config)"
 
-			controlplaneMachine := newMachine(cluster, "control-plane")
-			controlplaneMachine.ObjectMeta.Labels[clusterv1alpha2.MachineControlPlaneLabelName] = "true"
-			Expect(k8sClient.Create(context.Background(), controlplaneMachine)).To(Succeed())
+			 	There's a WIP PR to k/k to fix this.
+				After this merge, we can implement more behavioral test
 
-			controlplaneConfig := newKubeadmConfig(controlplaneMachine, "control-plane-config")
-			controlplaneConfig.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{}
-			controlplaneConfig.Spec.InitConfiguration = &kubeadmv1beta1.InitConfiguration{}
-			Expect(k8sClient.Create(context.Background(), controlplaneConfig)).To(Succeed())
+				It("should process only control plane machines when infrastructure is ready but control plane is not", func() {
+					cluster := newCluster("cluster2")
+					Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
+					cluster.Status.InfrastructureReady = true
+					Expect(k8sClient.Status().Update(context.Background(), cluster)).To(Succeed())
 
-			workerMachine := newMachine(cluster, "worker")
-			Expect(k8sClient.Create(context.Background(), workerMachine)).To(Succeed())
+					controlplaneMachine := newMachine(cluster, "control-plane")
+					controlplaneMachine.ObjectMeta.Labels[clusterv1alpha2.MachineControlPlaneLabelName] = "true"
+					Expect(k8sClient.Create(context.Background(), controlplaneMachine)).To(Succeed())
 
-			workerConfig := newKubeadmConfig(workerMachine, "worker-config")
-			Expect(k8sClient.Create(context.Background(), workerConfig)).To(Succeed())
+					controlplaneConfig := newKubeadmConfig(controlplaneMachine, "control-plane-config")
+					controlplaneConfig.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{}
+					controlplaneConfig.Spec.InitConfiguration = &kubeadmv1beta1.InitConfiguration{}
+					Expect(k8sClient.Create(context.Background(), controlplaneConfig)).To(Succeed())
 
-			reconciler := KubeadmConfigReconciler{
-				Log:    log.ZapLogger(true),
-				Client: k8sClient,
-			}
+					workerMachine := newMachine(cluster, "worker")
+					Expect(k8sClient.Create(context.Background(), workerMachine)).To(Succeed())
 
-			By("Calling reconcile on a config corresponding to worker node should requeue")
-			resultWorker, err := reconciler.Reconcile(ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "default",
-					Name:      "worker-config",
-				},
-			})
-			Expect(err).To(Succeed())
-			Expect(resultWorker.Requeue).To(BeFalse())
-			Expect(resultWorker.RequeueAfter).To(Equal(30 * time.Second))
+					workerConfig := newKubeadmConfig(workerMachine, "worker-config")
+					Expect(k8sClient.Create(context.Background(), workerConfig)).To(Succeed())
 
-			By("Calling reconcile on a config corresponding to a control plane node should create BootstrapData")
-			resultControlPlane, err := reconciler.Reconcile(ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: "default",
-					Name:      "control-plane-config",
-				},
-			})
-			Expect(err).To(Succeed())
-			Expect(resultControlPlane.Requeue).To(BeFalse())
-			Expect(resultControlPlane.RequeueAfter).To(BeZero())
+					reconciler := KubeadmConfigReconciler{
+						Log:    log.ZapLogger(true),
+						Client: k8sClient,
+					}
 
-			controlplaneConfigAfter, err := getKubeadmConfig(k8sClient, "control-plane-config")
-			Expect(err).To(Succeed())
-			Expect(controlplaneConfigAfter.Status.Ready).To(BeTrue())
-			Expect(controlplaneConfigAfter.Status.BootstrapData).NotTo(BeEmpty())
-		})
+					By("Calling reconcile on a config corresponding to worker node should requeue")
+					resultWorker, err := reconciler.Reconcile(ctrl.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: "default",
+							Name:      "worker-config",
+						},
+					})
+					Expect(err).To(Succeed())
+					Expect(resultWorker.Requeue).To(BeFalse())
+					Expect(resultWorker.RequeueAfter).To(Equal(30 * time.Second))
+
+					By("Calling reconcile on a config corresponding to a control plane node should create BootstrapData")
+					resultControlPlane, err := reconciler.Reconcile(ctrl.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: "default",
+							Name:      "control-plane-config",
+						},
+					})
+					Expect(err).To(Succeed())
+					Expect(resultControlPlane.Requeue).To(BeFalse())
+					Expect(resultControlPlane.RequeueAfter).To(BeZero())
+
+					controlplaneConfigAfter, err := getKubeadmConfig(k8sClient, "control-plane-config")
+					Expect(err).To(Succeed())
+					Expect(controlplaneConfigAfter.Status.Ready).To(BeTrue())
+					Expect(controlplaneConfigAfter.Status.BootstrapData).NotTo(BeEmpty())
+				})
+		*/
 	})
 })
 

--- a/controllers/kubeadmconfig_controller_test.go
+++ b/controllers/kubeadmconfig_controller_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kubeadmv1alpha2 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
+	cabpkV1alpha2 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -33,50 +35,19 @@ import (
 
 func setupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	v1alpha2.AddToScheme(scheme)
-	kubeadmv1alpha2.AddToScheme(scheme)
+	capiv1alpha2.AddToScheme(scheme)
+	cabpkV1alpha2.AddToScheme(scheme)
 	return scheme
 }
 
-func TestSuccessfulReconcileShouldNotRequeue(t *testing.T) {
+// Tests for misconfigurations / initial checks
+
+func TestBailIfKubeadmConfigStatusReady(t *testing.T) {
+	config := newKubeadmConfig(nil, "cfg") // NB. passing a machine is not relevant for this test
+	config.Status.Ready = true
+
 	objects := []runtime.Object{
-		&kubeadmv1alpha2.KubeadmConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "cfg",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind:       "Machine",
-						APIVersion: v1alpha2.SchemeGroupVersion.String(),
-						Name:       "my-machine",
-					},
-				},
-			},
-		},
-		&v1alpha2.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "my-machine",
-				Labels: map[string]string{
-					v1alpha2.MachineClusterLabelName: "my-cluster",
-				},
-			},
-		},
-		&v1alpha2.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "my-cluster",
-			},
-			Status: v1alpha2.ClusterStatus{
-				InfrastructureReady: true,
-				APIEndpoints: []v1alpha2.APIEndpoint{
-					{
-						Host: "example.com",
-						Port: 6443,
-					},
-				},
-			},
-		},
+		config,
 	}
 	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
 
@@ -96,24 +67,17 @@ func TestSuccessfulReconcileShouldNotRequeue(t *testing.T) {
 		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
 	}
 	if result.Requeue == true {
-		t.Fatal("did not expect to requeue")
+		t.Fatal("did not expected to requeue")
 	}
 	if result.RequeueAfter != time.Duration(0) {
-		t.Fatal("did not expect to requeue after")
+		t.Fatal("did not expected to requeue after")
 	}
 }
 
-func TestNoErrorIfNoMachineRefIsFound(t *testing.T) {
+func TestBailIfNoMachineRefIsSet(t *testing.T) {
+	config := newKubeadmConfig(nil, "cfg") // intentionally omitting machine
 	objects := []runtime.Object{
-		&kubeadmv1alpha2.KubeadmConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind: "some non machine kind",
-					},
-				},
-			},
-		},
+		config,
 	}
 	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
 
@@ -124,7 +88,7 @@ func TestNoErrorIfNoMachineRefIsFound(t *testing.T) {
 
 	request := ctrl.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: "ns",
+			Namespace: "default",
 			Name:      "cfg",
 		},
 	}
@@ -136,6 +100,564 @@ func TestNoErrorIfNoMachineRefIsFound(t *testing.T) {
 		t.Fatal("did not expected to requeue")
 	}
 	if result.RequeueAfter != time.Duration(0) {
-		t.Fatal("did not expect to requeue after")
+		t.Fatal("did not expected to requeue after")
 	}
+}
+
+func TestFailsIfMachineRefIsNotFound(t *testing.T) {
+	machine := newMachine(nil, "machine") // NB. passing a cluster is not relevant for this test
+	config := newKubeadmConfig(machine, "cfg")
+
+	objects := []runtime.Object{
+		// intentionally omitting machine
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}
+
+func TestBailIfMachineAlreadyHasBootstrapData(t *testing.T) {
+	machine := newMachine(nil, "machine") // NB. passing a cluster is not relevant for this test
+	machine.Spec.Bootstrap.Data = stringPtr("something")
+
+	config := newKubeadmConfig(machine, "cfg")
+	objects := []runtime.Object{
+		machine,
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+	result, err := k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(0) {
+		t.Fatal("did not expected to requeue after")
+	}
+}
+
+func TestFailsNoClusterRefIsSet(t *testing.T) {
+	machine := newMachine(nil, "machine") // intentionally omitting cluster
+	config := newKubeadmConfig(machine, "cfg")
+
+	objects := []runtime.Object{
+		machine,
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}
+
+func TestFailsIfClusterIsNotFound(t *testing.T) {
+	cluster := newCluster("cluster")
+	machine := newMachine(cluster, "machine")
+	config := newKubeadmConfig(machine, "cfg")
+
+	objects := []runtime.Object{
+		// intentionally omitting cluster
+		machine,
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}
+
+// Tests for cluster with infrastructure not ready yet
+
+func TestRequeueIfInfrastructureIsNotReady(t *testing.T) {
+	cluster := newCluster("cluster") // cluster by default has infrastructure not ready
+	machine := newMachine(cluster, "machine")
+	config := newKubeadmConfig(machine, "cfg")
+
+	objects := []runtime.Object{
+		cluster,
+		machine,
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+	result, err := k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(30*time.Second) {
+		t.Fatal("expected to requeue after 30s")
+	}
+}
+
+// Tests for cluster with infrastructure ready, but control pane not ready yet
+
+func TestRequeueKubeadmConfigForJoinNodesIfControlPlaneIsNotReady(t *testing.T) {
+	cluster := newCluster("cluster")
+	cluster.Status.InfrastructureReady = true
+
+	workerMachine := newWorkerMachine(cluster, "worker-machine")
+	workerJoinConfig := newWorkerJoinKubeadmConfig(workerMachine, "worker-join-cfg")
+
+	controlPaneMachine := newControlPlaneMachine(cluster, "control-plane-machine")
+	controlPaneJoinConfig := newControlPlaneJoinKubeadmConfig(controlPaneMachine, "control-plane-join-cfg")
+
+	objects := []runtime.Object{
+		cluster,
+		workerMachine,
+		workerJoinConfig,
+		controlPaneMachine,
+		controlPaneJoinConfig,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "worker-join-cfg",
+		},
+	}
+	result, err := k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(30*time.Second) {
+		t.Fatal("expected to requeue after 30s")
+	}
+
+	request = ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "control-plane-join-cfg",
+		},
+	}
+	result, err = k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(30*time.Second) {
+		t.Fatal("expected to requeue after 30s")
+	}
+}
+
+func TestReconcileKubeadmConfigForInitNodesIfControlPlaneIsNotReady(t *testing.T) {
+	cluster := newCluster("cluster")
+	cluster.Status.InfrastructureReady = true
+
+	controlPaneMachine := newControlPlaneMachine(cluster, "control-plane-machine")
+	controlPaneInitConfig := newControlPlaneInitKubeadmConfig(controlPaneMachine, "control-plane-init-cfg")
+
+	objects := []runtime.Object{
+		cluster,
+		controlPaneMachine,
+		controlPaneInitConfig,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "control-plane-init-cfg",
+		},
+	}
+	result, err := k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(0) {
+		t.Fatal("did not expected to requeue after")
+	}
+
+	cfg, err := getKubeadmConfig(myclient, "control-plane-init-cfg")
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+
+	if cfg.Status.Ready != true {
+		t.Fatal("Expected status ready")
+	}
+
+	if cfg.Status.BootstrapData == nil {
+		t.Fatal("Expected status ready")
+	}
+}
+
+// Tests for cluster with infrastructure ready, control pane ready
+
+func TestFailIfNotJoinConfigurationAndControlPlaneIsReady(t *testing.T) {
+	cluster := newCluster("cluster")
+	cluster.Status.InfrastructureReady = true
+	cluster.Annotations = map[string]string{ControlPlaneReadyAnnotationKey: "true"}
+
+	workerMachine := newWorkerMachine(cluster, "worker-machine")
+	workerJoinConfig := newWorkerJoinKubeadmConfig(workerMachine, "worker-join-cfg")
+	workerJoinConfig.Spec.JoinConfiguration = nil // Makes workerJoinConfig invalid
+
+	objects := []runtime.Object{
+		cluster,
+		workerMachine,
+		workerJoinConfig,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "worker-join-cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}
+
+func TestFailIfJoinConfigurationInconsistentWithMachineRole(t *testing.T) {
+	cluster := newCluster("cluster")
+	cluster.Status.InfrastructureReady = true
+	cluster.Annotations = map[string]string{ControlPlaneReadyAnnotationKey: "true"}
+
+	controlPaneMachine := newControlPlaneMachine(cluster, "control-plane-machine")
+	controlPaneJoinConfig := newControlPlaneJoinKubeadmConfig(controlPaneMachine, "control-plane-join-cfg")
+	controlPaneJoinConfig.Spec.JoinConfiguration.ControlPlane = nil // Makes controlPaneJoinConfig invalid for a control plane machine
+
+	objects := []runtime.Object{
+		cluster,
+		controlPaneMachine,
+		controlPaneJoinConfig,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "control-plane-join-cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}
+
+func TestFailIfMissingControlPaneEndpointAndControlPlaneIsReady(t *testing.T) {
+	cluster := newCluster("cluster")
+	cluster.Status.InfrastructureReady = true
+	cluster.Annotations = map[string]string{ControlPlaneReadyAnnotationKey: "true"}
+
+	workerMachine := newWorkerMachine(cluster, "worker-machine")
+	workerJoinConfig := newWorkerJoinKubeadmConfig(workerMachine, "worker-join-cfg")
+
+	objects := []runtime.Object{
+		cluster,
+		workerMachine,
+		workerJoinConfig,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "worker-join-cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+}
+
+func TestReconcileIfJoinNodesAndControlPlaneIsReady(t *testing.T) {
+	cluster := newCluster("cluster")
+	cluster.Status.InfrastructureReady = true
+	cluster.Annotations = map[string]string{ControlPlaneReadyAnnotationKey: "true"}
+	cluster.Status.APIEndpoints = []capiv1alpha2.APIEndpoint{{Host: "100.105.150.1", Port: 6443}}
+
+	workerMachine := newWorkerMachine(cluster, "worker-machine")
+	workerJoinConfig := newWorkerJoinKubeadmConfig(workerMachine, "worker-join-cfg")
+
+	controlPaneMachine := newControlPlaneMachine(cluster, "control-plane-machine")
+	controlPaneJoinConfig := newControlPlaneJoinKubeadmConfig(controlPaneMachine, "control-plane-join-cfg")
+
+	objects := []runtime.Object{
+		cluster,
+		workerMachine,
+		workerJoinConfig,
+		controlPaneMachine,
+		controlPaneJoinConfig,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.ZapLogger(true),
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "worker-join-cfg",
+		},
+	}
+	result, err := k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(0) {
+		t.Fatal("did not expected to requeue after")
+	}
+
+	cfg, err := getKubeadmConfig(myclient, "worker-join-cfg")
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+
+	if cfg.Status.Ready != true {
+		t.Fatal("Expected status ready")
+	}
+
+	if cfg.Status.BootstrapData == nil {
+		t.Fatal("Expected status ready")
+	}
+
+	request = ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "control-plane-join-cfg",
+		},
+	}
+	result, err = k.Reconcile(request)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+	if result.Requeue == true {
+		t.Fatal("did not expected to requeue")
+	}
+	if result.RequeueAfter != time.Duration(0) {
+		t.Fatal("did not expected to requeue after")
+	}
+
+	cfg, err = getKubeadmConfig(myclient, "control-plane-join-cfg")
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to reconcile:\n %+v", err))
+	}
+
+	if cfg.Status.Ready != true {
+		t.Fatal("Expected status ready")
+	}
+
+	if cfg.Status.BootstrapData == nil {
+		t.Fatal("Expected status ready")
+	}
+}
+
+// test utils
+
+// newCluster return a CAPI cluster object
+func newCluster(name string) *capiv1alpha2.Cluster {
+	return &capiv1alpha2.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: capiv1alpha2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+	}
+}
+
+// newMachine return a CAPI machine object; if cluster is not nil, the machine is linked to the cluster as well
+func newMachine(cluster *capiv1alpha2.Cluster, name string) *capiv1alpha2.Machine {
+	machine := &capiv1alpha2.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: capiv1alpha2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Spec: capiv1alpha2.MachineSpec{
+			Bootstrap: capiv1alpha2.Bootstrap{
+				ConfigRef: &v1.ObjectReference{
+					Kind:       "KubeadmConfig",
+					APIVersion: "v1alpha2",
+				},
+			},
+		},
+	}
+	if cluster != nil {
+		machine.ObjectMeta.Labels = map[string]string{
+			capiv1alpha2.MachineClusterLabelName: cluster.Name,
+		}
+	}
+	return machine
+}
+
+func newWorkerMachine(cluster *capiv1alpha2.Cluster, name string) *capiv1alpha2.Machine {
+	return newMachine(cluster, name) // machine by default is a worker node (not the boostrapNode)
+}
+
+func newControlPlaneMachine(cluster *capiv1alpha2.Cluster, name string) *capiv1alpha2.Machine {
+	m := newMachine(cluster, "control-plane-machine")
+	m.Labels[capiv1alpha2.MachineControlPlaneLabelName] = "true"
+	return m
+}
+
+// newKubeadmConfig return a CABPK KubeadmConfig object; if machine is not nil, the KubeadmConfig is linked to the machine as well
+func newKubeadmConfig(machine *capiv1alpha2.Machine, name string) *cabpkV1alpha2.KubeadmConfig {
+	config := &cabpkV1alpha2.KubeadmConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmConfig",
+			APIVersion: cabpkV1alpha2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+	}
+	if machine != nil {
+		config.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				Kind:       "Machine",
+				APIVersion: capiv1alpha2.SchemeGroupVersion.String(),
+				Name:       machine.Name,
+				UID:        types.UID(fmt.Sprintf("%s uid", machine.Name)),
+			},
+		}
+	}
+	return config
+}
+
+func newWorkerJoinKubeadmConfig(machine *capiv1alpha2.Machine, name string) *cabpkV1alpha2.KubeadmConfig {
+	c := newKubeadmConfig(machine, name)
+	c.Spec.JoinConfiguration = &kubeadmv1beta1.JoinConfiguration{
+		ControlPlane: nil,
+	}
+	return c
+}
+
+func newControlPlaneJoinKubeadmConfig(machine *capiv1alpha2.Machine, name string) *cabpkV1alpha2.KubeadmConfig {
+	c := newKubeadmConfig(machine, name)
+	c.Spec.JoinConfiguration = &kubeadmv1beta1.JoinConfiguration{
+		ControlPlane: &kubeadmv1beta1.JoinControlPlane{},
+	}
+	return c
+}
+
+func newControlPlaneInitKubeadmConfig(machine *capiv1alpha2.Machine, name string) *cabpkV1alpha2.KubeadmConfig {
+	c := newKubeadmConfig(machine, name)
+	c.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{}
+	c.Spec.InitConfiguration = &kubeadmv1beta1.InitConfiguration{}
+	return c
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
@ncdc @chuckha 
disclaimer: I'm still in learning mode.

This PR is an attempt to get the reconciler loop properly manage the creation of the init control plane. Main points I want to discuss with you:
1. While `cluster.x-k8s.io/infrastructure-ready` is not set, everything should wait
1. If `cluster.x-k8s.io/infrastructure-ready==true`, while `cluster.x-k8s.io/control-plane-ready` is not set
  1. we should ensure only one config/one machine is set for acting as init control plane; this requires the init-lock mechanism to be in place
  2. everything else should wait
1. if `cluster.x-k8s.io/infrastructure-ready==true` and `cluster.x-k8s.io/control-plane-ready==true the reconciler loop should handle join control plane and join workers  