### PR TITLE
Fix infrastructure ready

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -155,14 +155,8 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return ctrl.Result{}, nil
 	}
 
-	// Check for control-plane ready. If it's not ready then we will requeue the machine until it is.
-	// The infrastructure provider *must* set this value to use this bootstrap provider.
-	if cluster.Annotations == nil {
-		log.Info("No annotation exists on the cluster yet. Requeing until infrastructure is ready.")
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-	if cluster.Annotations[InfrastructureReadyAnnotationKey] != "true" {
-		log.Info("Infrastructure is not ready, requeing until ready.")
+	// Requeue until the machine is ready
+	if !cluster.Status.InfrastructureReady {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 

--- a/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -41,6 +41,9 @@ var _ = Describe("KubeadmConfigReconciler", func() {
 					Namespace: "default",
 					Name:      "my-cluster",
 				},
+				Status: clusterv1alpha2.ClusterStatus{
+					InfrastructureReady: true,
+				},
 			}
 			machine := &clusterv1alpha2.Machine{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This uses the infrastructureReady bool on the status instead of the Annotation. It may not be in the right spot, but @fabriziopandini is working on that.

```release-note
NONE
```

/assign @fabianofranz @ncdc 