### PR TITLE
use AdditionalUserDataFiles in bootstrap data generation

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -196,6 +196,9 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		certificates, _ := r.getCertificates()
 
 		cloudInitData, err := cloudinit.NewInitControlPlane(&cloudinit.ControlPlaneInput{
+			BaseUserData: cloudinit.BaseUserData{
+				AdditionalFiles: config.Spec.AdditionalUserDataFiles,
+			},
 			InitConfiguration:    string(initdata),
 			ClusterConfiguration: string(clusterdata),
 			Certificates:         certificates,
@@ -257,6 +260,9 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		joinData, err := cloudinit.NewJoinControlPlane(&cloudinit.ControlPlaneJoinInput{
 			JoinConfiguration: string(joinBytes),
 			Certificates:      certificates,
+			BaseUserData: cloudinit.BaseUserData{
+				AdditionalFiles: config.Spec.AdditionalUserDataFiles,
+			},
 		})
 		if err != nil {
 			log.Error(err, "failed to create a control plane join configuration")
@@ -273,6 +279,9 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	joinData, err := cloudinit.NewNode(&cloudinit.NodeInput{
+		BaseUserData: cloudinit.BaseUserData{
+			AdditionalFiles: config.Spec.AdditionalUserDataFiles,
+		},
 		JoinConfiguration: string(joinBytes),
 	})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR wires up AdditionalUserDataFiles to generation code

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #90 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
