### PR TITLE
Set GOPROXY to default if it is not configured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
-GOPROXY ?= https://proxy.golang.org
+ifeq ($(GOPROXY),)
+GOPROXY := https://proxy.golang.org
+endif
 export GOPROXY
 
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is necessary since `go env GOPROXY` will return an empty string if the value is not set, thus setting GOPROXY to an empty string, which doesn't quite do what we want.

**Special notes for your reviewer**:

I've verified this locally by doing a fresh checkout without `GOPROXY` being set and running `make test`, which resulted in:
```
verifying gomodules.xyz/jsonpatch/v2@v2.0.0: checksum mismatch
	downloaded: h1:OyHbl+7IOECpPKfVK42oFr6N7+Y2dR+Jsb/IiDV3hOo=
	go.sum:     h1:lHNQverf0+Gm1TbSbVIDWVXOhZ2FpZopxRqpr2uIjs4=
make: *** [fmt] Error 1
```

After applying this change and running `make test` again things worked as expected.

**Release note**:
```release-note
NONE
```

/cc @chuckha @amy 