### PR TITLE
Use CAPI utils to reduce boilerplate

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -76,30 +76,14 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return ctrl.Result{}, nil
 	}
 
-	// Find the owner reference
-	// The cluster-api machine controller set this value.
-	var machineRef *v1.OwnerReference
-	for _, ref := range config.OwnerReferences {
-		if ref.Kind == machineKind.Kind && ref.APIVersion == machineKind.GroupVersion().String() {
-			machineRef = &ref
-			break
-		}
-	}
-	if machineRef == nil {
-		log.Info("did not find matching machine reference")
-		return ctrl.Result{}, nil
-	}
-
-	// Get the machine
-	machine := &capiv1alpha2.Machine{}
-	machineKey := client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      machineRef.Name,
-	}
-
-	if err := r.Get(ctx, machineKey, machine); err != nil {
-		log.Error(err, "failed to get machine")
+	machine, err := util.GetOwnerMachine(ctx, r.Client, config.ObjectMeta)
+	if err != nil {
+		log.Error(err, "could not get owner machine")
 		return ctrl.Result{}, err
+	}
+	if machine == nil {
+		log.Info("Waiting for Machine Controller to set OwnerRef on the KubeadmConfig")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ignore machines that already have bootstrap data
@@ -107,18 +91,9 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return ctrl.Result{}, nil
 	}
 
-	if machine.Labels[capiv1alpha2.MachineClusterLabelName] == "" {
-		return ctrl.Result{}, errors.New("machine has no associated cluster")
-	}
-
-	// Get the cluster
-	cluster := &capiv1alpha2.Cluster{}
-	clusterKey := client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      machine.Labels[capiv1alpha2.MachineClusterLabelName],
-	}
-	if err := r.Get(ctx, clusterKey, cluster); err != nil {
-		log.Error(err, "failed to get cluster")
+	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
+	if err != nil {
+		log.Error(err, "could not get cluster by machine metadata")
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/kubeadmconfig_controller_test.go
+++ b/controllers/kubeadmconfig_controller_test.go
@@ -74,7 +74,7 @@ func TestBailIfKubeadmConfigStatusReady(t *testing.T) {
 	}
 }
 
-func TestBailIfNoMachineRefIsSet(t *testing.T) {
+func TestRequeueIfNoMachineRefIsSet(t *testing.T) {
 	config := newKubeadmConfig(nil, "cfg") // intentionally omitting machine
 	objects := []runtime.Object{
 		config,
@@ -99,8 +99,8 @@ func TestBailIfNoMachineRefIsSet(t *testing.T) {
 	if result.Requeue == true {
 		t.Fatal("did not expected to requeue")
 	}
-	if result.RequeueAfter != time.Duration(0) {
-		t.Fatal("did not expected to requeue after")
+	if result.RequeueAfter == time.Duration(0) {
+		t.Fatal("Expected a requeue but did not get one")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cluster-bootstrap v0.0.0-20190516232516-d7d78ab2cfe7
 	k8s.io/klog v0.3.3
-	sigs.k8s.io/cluster-api v0.0.0-20190725170330-835ee872f98d
-	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a // indirect
+	sigs.k8s.io/cluster-api v0.0.0-20190809134526-b8af96f0a42a
+	sigs.k8s.io/controller-runtime v0.2.0-beta.5
 )

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -248,11 +249,13 @@ k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 h1:VBM/0P5TWxwk+Nw6Z+lAw3DKgO76g90ETOiA6rfLV1Y=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-sigs.k8s.io/cluster-api v0.0.0-20190725170330-835ee872f98d h1:DjeaMyqyw5tpps/prbudaojzp8gRMPV6L6MU4C8M8Eg=
-sigs.k8s.io/cluster-api v0.0.0-20190725170330-835ee872f98d/go.mod h1:DIiQEP2FjsAiEgBTgT5EEUAVM7XRy7aLgeERFXvZHaQ=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4 h1:S1XVfRWR1MuIXZdkYx3jN8JDw+bbQxmWZroy0i87z/A=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
-sigs.k8s.io/controller-tools v0.2.0-beta.4/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
+k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a h1:2jUDc9gJja832Ftp+QbDV0tVhQHMISFn01els+2ZAcw=
+k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+sigs.k8s.io/cluster-api v0.0.0-20190809134526-b8af96f0a42a h1:aDiczQxkpWlxe5yzqm6rJNe5orMuHTt7Q0MqDJOJ/bg=
+sigs.k8s.io/cluster-api v0.0.0-20190809134526-b8af96f0a42a/go.mod h1:CgxuxJy6W8onO8duP2ED+s0kwNxsNWIGEXMnSUsxGcw=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5 h1:W2jTb239QEwQ+HejhTCF9GriFPy2zmo1I6pPmJTeEy8=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
+sigs.k8s.io/controller-tools v0.2.0-beta.5/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/testing_frameworks v0.1.2-0.20190130140139-57f07443c2d4 h1:GtDhkj3cF4A4IW+A9LScsuxvJqA9DE7G7PGH1f8B07U=
 sigs.k8s.io/testing_frameworks v0.1.2-0.20190130140139-57f07443c2d4/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR uses the util code and removes some boilerplate making the Reconcile function shorter and easier to read.

It also bumps CAPI version and refactors some test logic.

**Release note**:
```release-note
NONE
```
