### PR TITLE
chore: get kubeadm yaml rather than json

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -149,7 +148,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 				},
 			}
 		}
-		initdata, err := json.Marshal(config.Spec.InitConfiguration)
+		initdata, err := kubeadmv1beta1.ConfigurationToYAML(config.Spec.InitConfiguration)
 		if err != nil {
 			log.Error(err, "failed to marshal init configuration")
 			return ctrl.Result{}, err
@@ -166,10 +165,10 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 		// If there is a control plane endpoint defined at cluster in cluster status, use it as a control plane endpoint for the K8s cluster
 		// NB. we are only using the first one defined if there are multiple defined.
 		if len(cluster.Status.APIEndpoints) > 0 {
-			config.Spec.ClusterConfiguration.ControlPlaneEndpoint = fmt.Sprintf("https://%s:%d", cluster.Status.APIEndpoints[0].Host, cluster.Status.APIEndpoints[0].Port)
+			config.Spec.ClusterConfiguration.ControlPlaneEndpoint = fmt.Sprintf("%s:%d", cluster.Status.APIEndpoints[0].Host, cluster.Status.APIEndpoints[0].Port)
 		}
 
-		clusterdata, err := json.Marshal(config.Spec.ClusterConfiguration)
+		clusterdata, err := kubeadmv1beta1.ConfigurationToYAML(config.Spec.ClusterConfiguration)
 		if err != nil {
 			log.Error(err, "failed to marshal cluster configuration")
 			return ctrl.Result{}, err
@@ -215,7 +214,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 
 	config.Spec.JoinConfiguration.Discovery.BootstrapToken.APIServerEndpoint = fmt.Sprintf("https://%s:%d", cluster.Status.APIEndpoints[0].Host, cluster.Status.APIEndpoints[0].Port)
 
-	joinBytes, err := json.Marshal(config.Spec.JoinConfiguration)
+	joinBytes, err := kubeadmv1beta1.ConfigurationToYAML(config.Spec.JoinConfiguration)
 	if err != nil {
 		log.Error(err, "failed to marshal join configuration")
 		return ctrl.Result{}, err

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,7 @@ k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible/go.mod h1:7v
 k8s.io/cluster-bootstrap v0.0.0-20190516232516-d7d78ab2cfe7 h1:5wvjieVoU4oovHlkeD256q2M2YYi2P01zk6wxSR2zk0=
 k8s.io/cluster-bootstrap v0.0.0-20190516232516-d7d78ab2cfe7/go.mod h1:iBSm2nwo3OaiuW8VDvc3ySDXK5SKfUrxwPvBloKG7zg=
 k8s.io/code-generator v0.0.0-20190311093542-50b561225d70/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
+k8s.io/component-base v0.0.0-20190409021516-bd2732e5c3f7 h1:f+AySqWvoqyCD7aArN3EZ+g2boKIS52pcSo6zdZkc+4=
 k8s.io/component-base v0.0.0-20190409021516-bd2732e5c3f7/go.mod h1:DMaomcf3j3MM2j1FsvlLVVlc7wA2jPytEur3cP9zRxQ=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/kubeadm/v1beta1/groupversion_info.go
+++ b/kubeadm/v1beta1/groupversion_info.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "kubeadm.k8s.io", Version: "v1beta1"}
+)

--- a/kubeadm/v1beta1/utils.go
+++ b/kubeadm/v1beta1/utils.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"github.com/pkg/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+// GetCodecs returns a type that can be used to deserialize most kubeadm
+// configuration types.
+func GetCodecs() serializer.CodecFactory {
+	sb := &scheme.Builder{GroupVersion: GroupVersion}
+
+	sb.Register(&JoinConfiguration{}, &InitConfiguration{}, &ClusterConfiguration{})
+	kubeadmScheme, err := sb.Build()
+	if err != nil {
+		panic(err)
+	}
+	return serializer.NewCodecFactory(kubeadmScheme)
+}
+
+// ConfigurationToYAML converts a kubeadm configuration type to its YAML
+// representation.
+func ConfigurationToYAML(obj runtime.Object) (string, error) {
+	initcfg, err := MarshalToYamlForCodecs(obj, GroupVersion, GetCodecs())
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal configuration")
+	}
+	return string(initcfg), nil
+}
+
+// MarshalToYamlForCodecs marshals an object into yaml using the specified codec
+// TODO: Is specifying the gv really needed here?
+// TODO: Can we support json out of the box easily here?
+func MarshalToYamlForCodecs(obj runtime.Object, gv schema.GroupVersion, codecs serializer.CodecFactory) ([]byte, error) {
+	mediaType := "application/yaml"
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		return []byte{}, errors.Errorf("unsupported media type %q", mediaType)
+	}
+
+	encoder := codecs.EncoderForVersion(info.Serializer, gv)
+	return runtime.Encode(encoder, obj)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Currently, the userdata has the kubeadm config structs as json, which kubeadm doesn't seem to like.

Sample from a provisioned host:
```
---
{"nodeRegistration":{"kubeletExtraArgs":{"cni-bin-dir":"/opt/cni/bin","cni-conf-dir":"/etc/cni/net.d","network-plugin":"cni","node-ip":"<redacted>"}},"localAPIEndpoint":{"advertiseAddress":"","bindPort":0}}
```

**Special notes for your reviewer**:

To avoid importing k/k I grabbed a utility function and copied it here, MarshalToYamlForCodecs.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
