### PR TITLE
Only one node should do kubeadm init

### DIFF
--- a/controllers/control_plane_init_locker.go
+++ b/controllers/control_plane_init_locker.go
@@ -125,7 +125,6 @@ func (l *controlPlaneInitLocker) Release(cluster *clusterv2.Cluster) bool {
 }
 
 func (l *controlPlaneInitLocker) configMapExists(namespace, name string) (bool, error) {
-	// _, err := l.configMapClient.ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 	cfg := &apicorev1.ConfigMap{}
 	err := l.client.Get(l.ctx, client.ObjectKey{
 		Namespace: namespace,

--- a/controllers/control_plane_init_locker.go
+++ b/controllers/control_plane_init_locker.go
@@ -80,8 +80,7 @@ func (l *controlPlaneInitLocker) Acquire(cluster *clusterv2.Cluster) bool {
 	}
 
 	log.Info("Attempting to create control plane configmap lock")
-	err = l.client.Create(l.ctx, controlPlaneConfigMap)
-	if err != nil {
+	if err := l.client.Create(l.ctx, controlPlaneConfigMap); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			// Someone else beat us to it
 			log.Info("Control plane configmap lock already exists")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR prevents the bootstrapper to run kubeadm init on two nodes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #99 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/assign @chuckha 
/assign @fabriziopandini 
