### PR TITLE
Set the args in the manager_auth_proxy_patch.yaml

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,3 +22,5 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+        - --v=4
+        - --enable-leader-election

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,9 +23,7 @@ spec:
         control-plane: cabpk-controller-manager
     spec:
       containers:
-      - args:
-        - --enable-leader-election
-        image: controller:latest
+      - image: controller:latest
         imagePullPolicy: Always
         name: manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR is one solution to #129. It may not be optimal but does at least work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #129

**Special notes for your reviewer**:
If this args is added to the manager_image_patch then there is a patch merge conflict.

**Release note**:

```release-note
NONE
```