### PR TITLE
Clean up some misleading logs

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -118,12 +118,11 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 		}
 	}()
 
-	// Check for control plane ready. If it's not ready then we will requeue the machine until it is.
-	// The cluster-api machine controller set this value.
+	// Init the control plane
 	if cluster.Annotations[ControlPlaneReadyAnnotationKey] != "true" {
 		// if it's NOT a control plane machine, requeue
 		if !util.IsControlPlaneMachine(machine) {
-			log.Info("Control plane is not ready, requeing worker nodes until ready.")
+			log.Info(fmt.Sprintf("Machine is not a control plane. If it should be a control plane, add `%s: true` as a label to the Machine", capiv1alpha2.MachineControlPlaneLabelName))
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR cleans up some misleading logs and provides a nicer experience when a machine might be a control plane machine.

/assign @fabriziopandini @detiber 

**Release note**:
```release-note
NONE
```