### PR TITLE
Handle setting of ClusterConfiguration.ClusterName

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -184,6 +184,10 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 			log.Info("Altering ClusterConfiguration", "ControlPlaneEndpoint", config.Spec.ClusterConfiguration.ControlPlaneEndpoint)
 		}
 
+		if config.Spec.ClusterConfiguration.ClusterName == "" {
+			config.Spec.ClusterConfiguration.ClusterName = cluster.Name
+		}
+
 		clusterdata, err := kubeadmv1beta1.ConfigurationToYAML(config.Spec.ClusterConfiguration)
 		if err != nil {
 			log.Error(err, "failed to marshal cluster configuration")


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously we were attempting to retrieve the kubeconfig secret using ClusterConfiguration.ClusterName, but we weren't ensuring that the value defaulted to the name of the linked Cluster.

**Release note**:
```release-note
NONE
```
