### PR TITLE
production ready dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.12.7 as builder
+FROM golang:1.12.7
 
 # default the go proxy
 ARG goproxy=https://proxy.golang.org
@@ -22,7 +22,6 @@ ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
@@ -30,15 +29,19 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY ./ ./
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY kubeadm/ kubeadm/
+COPY cloudinit/ cloudinit/
+COPY certs/ certs/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+# Allow containerd to restart pods by calling /restart.sh (mostly for tilt + fast dev cycles)
+# TODO: Remove this on prod and use a multi-stage build
+COPY third_party/forked/rerun-process-wrapper/start.sh .
+COPY third_party/forked/rerun-process-wrapper/restart.sh .
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
-WORKDIR /
-COPY --from=builder /workspace/manager .
-USER nobody
-ENTRYPOINT ["/manager"]
+# Build and run
+RUN go install -v .
+RUN mv /go/bin/cluster-api-bootstrap-provider-kubeadm /manager
+ENTRYPOINT ["./start.sh", "/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the current `Dockerfile` into `Dockerfile.dev` and adds a production-ready  `Dockerfile` ("kubebuilder2" bases + GOPROXY + USER nobody) 

**Release note**:
```release-note
NONE
```

/assign @vincepri @chuckha 
