### PR TITLE
Adds goreleaser image pushing

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -1,0 +1,44 @@
+name: Latest
+on:
+  push:
+    branches:
+    - master
+jobs:
+  latest:
+    name: Latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.12
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Install goreleaser
+        run: |
+          curl -sLO https://github.com/goreleaser/goreleaser/releases/download/v0.116.0/goreleaser_amd64.deb
+          sudo dpkg -i goreleaser_amd64.deb
+          rm goreleaser_amd64.deb
+
+      - name: GCR Setup
+        uses: actions/gcloud/auth@master
+        env:
+          GCLOUD_AUTH: ${{ secrets.MY_GCLOUD_AUTH }}
+
+      - name: GCR Auth
+        uses: actions/gcloud/cli@master
+        with:
+          args: "auth configure-docker"
+
+      - name: Runs goreleaser
+        run: goreleaser release --snapshot --skip-publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+      - name: push images
+        uses: actions/gcloud/cli@master
+        with:
+          args: "docker -- push gcr.io/k8s-staging-capi-kubeadm/manager"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,22 @@
+builds:
+  - env:
+      - CGO_ENABLED=0
+      - GOPROXY=https://proxy.golang.org
+    goos:
+      - linux
+    goarch:
+      - amd64
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^Merge pull request'
+dockers:
+  - goos: linux
+    goarch: amd64
+    dockerfile: goreleaser.dockerfile
+    skip_push: true
+    image_templates:
+      - 'gcr.io/k8s-staging-capi-kubeadm/manager:latest'

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/distroless/static:latest
+WORKDIR /
+COPY cluster-api-bootstrap-provider-kubeadm /manager
+USER nobody
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR will push a new :latest image to the staging bucket on every push to master.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #52 

**Special notes for your reviewer**:
This still requires a secret of `MY_GCLOUD_AUTH` which should be generated from a service account on the `k8s-staging-capi-kubeadm` project with `Storage Admin` permissions.

If you create that service account you can run these commands and add them as a secret to this repo:

```
1. gcloud iam service-accounts keys create github-key.json --iam-account=github-image-pusher@ k8s-staging-capi-kubeadm.iam.gserviceaccount.com
2. cat github-key.json | base64
3. => copy that into a secret named MY_GCLOUD_AUTH
```

/hold 
holding until that GCLOUD AUTH gets added.

cc @vincepri 