### PR TITLE
Add 'help' target to Makefile and make it the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# If you update this file, please follow:
+# https://suva.sh/posts/well-documented-makefiles/
+
+.DEFAULT_GOAL:=help
+
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)
@@ -47,68 +52,59 @@ export GO111MODULE=on
 .PHONY: all
 all: manager
 
-# Run tests
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
 .PHONY: test
-test: generate fmt vet
+test: generate fmt vet ## Run tests
 	go test ./api/... ./certs/... ./controllers/... -coverprofile cover.out
 
-# Build manager binary
 .PHONY: manager
-manager: generate fmt vet
+manager: generate fmt vet ## Build manager binary
 	go build -o bin/manager main.go
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
-run: generate fmt vet
+run: generate fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./main.go
 
-# Install CRDs into a cluster
 .PHONY: install
-install: generate
+install: generate ## Install CRDs into a cluster
 	kubectl apply -f config/crd/bases
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
-deploy: generate
+deploy: generate ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	kubectl apply -f config/crd/bases
 	kubectl kustomize config/default | kubectl apply -f -
 
-# Run go fmt against code
 .PHONY: fmt
-fmt:
+fmt: ## Run go fmt against code
 	go fmt ./...
 
-# Run go vet against code
 .PHONY: vet
-vet:
+vet: ## Run go vet against code
 	go vet ./...
 
-# Generate code
 .PHONY: generate
-generate: $(CONTROLLER_GEN)
+generate: $(CONTROLLER_GEN) ## Generate code
 	$(MAKE) generate-manifests
 	$(MAKE) generate-deepcopy
 
-# Generate deepcopy files.
 .PHONY: generate-deepcopy
-generate-deepcopy: $(CONTROLLER_GEN)
+generate-deepcopy: $(CONTROLLER_GEN) ## Generate deepcopy files.
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate/boilerplate.generatego.txt paths=./api/...
 
-# Generate manifests e.g. CRD, RBAC etc.
 .PHONY: generate-manifests
-generate-manifests: $(CONTROLLER_GEN)
+generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:dir=$(CRD_ROOT) output:webhook:dir=$(WEBHOOK_ROOT) output:rbac:dir=$(RBAC_ROOT)
 
-# Build the docker image
 .PHONY: docker-build
-docker-build: test
+docker-build: test ## Build the docker image
 	docker build . -t ${MANAGER_IMAGE}
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"${MANAGER_IMAGE}"'@' ./config/default/manager_image_patch.yaml
 
-# Push the docker image
 .PHONY: docker-push
-docker-push:
+docker-push: ## Push the docker image
 	docker push ${MANAGER_IMAGE}
 
 # Build controller-gen


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes it easier to figure out what commands are available via make without having to read through the Makefile. Implemented using the changes from kubernetes-sigs/cluster-api#631.

```shell
$ make help

Usage:
  make <target>
  help                  Display this help
  test                  Run tests
  manager               Build manager binary
  run                   Run against the configured Kubernetes cluster in ~/.kube/config
  install               Install CRDs into a cluster
  deploy                Deploy controller in the configured Kubernetes cluster in ~/.kube/config
  fmt                   Run go fmt against code
  vet                   Run go vet against code
  generate              Generate code
  generate-deepcopy     Generate deepcopy files.
  generate-manifests    Generate manifests e.g. CRD, RBAC etc.
  docker-build          Build the docker image
  docker-push           Push the docker image
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
