### PR TITLE
📖Set the manager image patch + release docs

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     spec:
       containers:
-      # Change the value of image field below to your controller image URL
-      - image: IMAGE_URL
+      # Change the value of image field to the new version before a release
+      - image: gcr.io/k8s-staging-capi-kubeadm/manager:latest
         name: manager

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,15 @@
+# How to release this project
+
+0. Make sure the manger image patch is pointed to the image tag you will be releasing.
+    0. If it is not, update it and open a PR. This is the commit you will use to release.
+1. `git pull` to get the latest merge commit.
+1. Tag the merge commit.
+1. Push the tag.
+2. GithubActions take over from here.
+3. Update the release notes.
+4. Send notifications to relevant slack channels and mailing lists.
+
+## Expected artifacts
+
+1. A release with no binaries.
+2. A container image pushed to the staging bucket tagged with the released version.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR defines a release process + the boundaries of GitHub acitons

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #52 

**Special notes for your reviewer**:

**Release note**:
```release-note
Improve user experience by having a valid `manager_image_patch.yaml` file.
```