### PR TITLE
✨Check if the Control Plane is initialized before generating JoinConfigurations

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -265,6 +265,12 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 		return ctrl.Result{}, nil
 	}
 
+	// Return early if the status ControlPlaneInitialized isn't ready.
+	if !cluster.Status.ControlPlaneInitialized {
+		log.Info("Control plane is not initialized, waiting until ready.")
+		return ctrl.Result{}, nil
+	}
+
 	// Every other case it's a join scenario
 	// Nb. in this case ClusterConfiguration and JoinConfiguration should not be defined by users, but in case of misconfigurations, CABPK simply ignore them
 

--- a/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -45,8 +45,9 @@ var _ = Describe("KubeadmConfigReconciler", func() {
 			Expect(k8sClient.Create(context.Background(), config)).To(Succeed())
 
 			reconciler := KubeadmConfigReconciler{
-				Log:    log.Log,
-				Client: k8sClient,
+				Log:             log.Log,
+				Client:          k8sClient,
+				KubeadmInitLock: &myInitLocker{},
 			}
 			By("Calling reconcile should requeue")
 			result, err := reconciler.Reconcile(ctrl.Request{


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
