### PR TITLE
:sparkles: Add cluster-api group to KubeadmConfigTemplate

### DIFF
--- a/api/v1alpha2/kubeadmconfigtemplate_types.go
+++ b/api/v1alpha2/kubeadmconfigtemplate_types.go
@@ -26,7 +26,7 @@ type KubeadmConfigTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=kubeadmconfigtemplates,scope=Namespaced
+// +kubebuilder:resource:path=kubeadmconfigtemplates,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 
 // KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: bootstrap.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: KubeadmConfigTemplate
     plural: kubeadmconfigtemplates
   scope: Namespaced


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the cluster-api group to the KubeadmConfigTemplate type
