### PR TITLE
:warning: Adds encoding field for cloud-init files

### DIFF
--- a/api/v1alpha2/kubeadmbootstrapconfig_types.go
+++ b/api/v1alpha2/kubeadmbootstrapconfig_types.go
@@ -108,16 +108,16 @@ func init() {
 }
 
 // Encoding specifies the cloud-init file encoding.
-// +kubebuilder:validation:Enum=b64;gzip;gz+b64
+// +kubebuilder:validation:Enum=base64;gzip;gzip+base64
 type Encoding string
 
 const (
 	// Base64 implies the contents of the file are encoded as base64.
-	Base64 Encoding = "b64"
+	Base64 Encoding = "base64"
 	// Gzip implies the contents of the file are encoded with gzip.
 	Gzip Encoding = "gzip"
 	// GzipBase64 implies the contents of the file are first base64 encoded and then gzip encoded.
-	GzipBase64 Encoding = "gz+b64"
+	GzipBase64 Encoding = "gzip+base64"
 )
 
 // File defines the input for generating write_files in cloud-init.

--- a/api/v1alpha2/kubeadmbootstrapconfig_types.go
+++ b/api/v1alpha2/kubeadmbootstrapconfig_types.go
@@ -107,6 +107,19 @@ func init() {
 	SchemeBuilder.Register(&KubeadmConfig{}, &KubeadmConfigList{})
 }
 
+// Encoding specifies the cloud-init file encoding.
+// +kubebuilder:validation:Enum=b64;gzip;gz+b64
+type Encoding string
+
+const (
+	// Base64 implies the contents of the file are encoded as base64.
+	Base64 Encoding = "b64"
+	// Gzip implies the contents of the file are encoded with gzip.
+	Gzip Encoding = "gzip"
+	// GzipBase64 implies the contents of the file are first base64 encoded and then gzip encoded.
+	GzipBase64 Encoding = "gz+b64"
+)
+
 // File defines the input for generating write_files in cloud-init.
 type File struct {
 	// Path specifies the full path on disk where to store the file.
@@ -119,6 +132,10 @@ type File struct {
 	// Permissions specifies the permissions to assign to the file, e.g. "0640".
 	// +optional
 	Permissions string `json:"permissions,omitempty"`
+
+	// Encoding specifies the encoding of the file contents.
+	// +optional
+	Encoding Encoding `json:"encoding,omitempty"`
 
 	// Content is the actual content of the file.
 	Content string `json:"content"`

--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -73,7 +73,7 @@ func TestNewInitControlPlaneAdditionalFileEncodings(t *testing.T) {
 	}
 	expectedFiles := []string{
 		`-   path: /tmp/my-path
-    encoding: "b64"
+    encoding: "base64"
     content: |
       aGk=`,
 		`-   path: /tmp/my-other-path

--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudinit
+
+import (
+	"bytes"
+	"testing"
+
+	infrav1 "sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/api/v1alpha2"
+	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/certs"
+)
+
+func TestNewInitControlPlaneAdditionalFileEncodings(t *testing.T) {
+	cpinput := &ControlPlaneInput{
+		BaseUserData: BaseUserData{
+			Header:              "test",
+			PreKubeadmCommands:  nil,
+			PostKubeadmCommands: nil,
+			AdditionalFiles: []infrav1.File{
+				{
+					Path:     "/tmp/my-path",
+					Encoding: infrav1.Base64,
+					Content:  "aGk=",
+				},
+				{
+					Path:    "/tmp/my-other-path",
+					Content: "hi",
+				},
+			},
+			WriteFiles: nil,
+			Users:      nil,
+			NTP:        nil,
+		},
+		Certificates: certs.Certificates{
+			ClusterCA: &certs.KeyPair{
+				Cert: []byte("ca cert"),
+				Key:  []byte("ca key"),
+			},
+			EtcdCA: &certs.KeyPair{
+				Cert: []byte("etcd ca cert"),
+				Key:  []byte("etcd ca key"),
+			},
+			FrontProxyCA: &certs.KeyPair{
+				Cert: []byte("front proxy ca cert"),
+				Key:  []byte("front proxy ca key"),
+			},
+			ServiceAccount: &certs.KeyPair{
+				Cert: []byte("service account ca cert"),
+				Key:  []byte("service account ca key"),
+			},
+		},
+		ClusterConfiguration: "my-cluster-config",
+		InitConfiguration:    "my-init-config",
+	}
+
+	out, err := NewInitControlPlane(cpinput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedFiles := []string{
+		`-   path: /tmp/my-path
+    encoding: "b64"
+    content: |
+      aGk=`,
+		`-   path: /tmp/my-other-path
+    content: |
+      hi`,
+	}
+	for _, f := range expectedFiles {
+		if !bytes.Contains(out, []byte(f)) {
+			t.Errorf("%s\ndid not contain\n%s", out, f)
+		}
+	}
+}

--- a/cloudinit/files.go
+++ b/cloudinit/files.go
@@ -20,7 +20,9 @@ const (
 	filesTemplate = `{{ define "files" -}}
 write_files:{{ range . }}
 -   path: {{.Path}}
-    encoding: "base64"
+    {{ if ne .Encoding "" -}}
+    encoding: "{{.Encoding}}"
+    {{ end -}}
     {{ if ne .Owner "" -}}
     owner: {{.Owner}}
     {{ end -}}
@@ -28,7 +30,7 @@ write_files:{{ range . }}
     permissions: '{{.Permissions}}'
     {{ end -}}
     content: |
-{{.Content | Base64Encode | Indent 6}}
+{{.Content | Indent 6}}
 {{- end -}}
 {{- end -}}
 `

--- a/cloudinit/utils.go
+++ b/cloudinit/utils.go
@@ -17,21 +17,15 @@ limitations under the License.
 package cloudinit
 
 import (
-	"encoding/base64"
 	"strings"
 	"text/template"
 )
 
 var (
 	defaultTemplateFuncMap = template.FuncMap{
-		"Base64Encode": templateBase64Encode,
-		"Indent":       templateYAMLIndent,
+		"Indent": templateYAMLIndent,
 	}
 )
-
-func templateBase64Encode(s string) string {
-	return base64.StdEncoding.EncodeToString([]byte(s))
-}
 
 func templateYAMLIndent(i int, input string) string {
 	split := strings.Split(input, "\n")

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -362,9 +362,9 @@ spec:
                   encoding:
                     description: Encoding specifies the encoding of the file contents.
                     enum:
-                    - b64
+                    - base64
                     - gzip
-                    - gz+b64
+                    - gzip+base64
                     type: string
                   owner:
                     description: Owner specifies the ownership of the file, e.g. "root:root".

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -359,6 +359,13 @@ spec:
                   content:
                     description: Content is the actual content of the file.
                     type: string
+                  encoding:
+                    description: Encoding specifies the encoding of the file contents.
+                    enum:
+                    - b64
+                    - gzip
+                    - gz+b64
+                    type: string
                   owner:
                     description: Owner specifies the ownership of the file, e.g. "root:root".
                     type: string

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -380,6 +380,14 @@ spec:
                           content:
                             description: Content is the actual content of the file.
                             type: string
+                          encoding:
+                            description: Encoding specifies the encoding of the file
+                              contents.
+                            enum:
+                            - b64
+                            - gzip
+                            - gz+b64
+                            type: string
                           owner:
                             description: Owner specifies the ownership of the file,
                               e.g. "root:root".

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -384,9 +384,9 @@ spec:
                             description: Encoding specifies the encoding of the file
                               contents.
                             enum:
-                            - b64
+                            - base64
                             - gzip
-                            - gz+b64
+                            - gzip+base64
                             type: string
                           owner:
                             description: Owner specifies the ownership of the file,


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds an Encoding type for the cloud init files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #202 

/assign @detiber 
