### PR TITLE
🐛 Fix golangci-lint config to ignore unhelpful lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,9 +26,12 @@ linters:
     - gocyclo
     - lll
   fast: true
-issue:
+issues:
   max-same-issues: 0
   max-per-linter: 0
+  # List of regexps of issue texts to exclude, empty list by default.
+  exclude:
+    - Using the variable on range scope `tc` in function literal
 run:
   deadline: 2m
   skip-dirs:


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

Fixes a typo in the golint-ci config file and adds an exclude to ignore shadowing in test cases.

