### PR TITLE
:bug: Fix error-return for machine-cluster association

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -127,6 +127,16 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	// Lookup the cluster the machine is associated with
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
 	if err != nil {
+		if errors.Cause(err) == util.ErrNoCluster {
+			log.Info("Machine does not belong to a cluster yet, waiting until its part of a cluster")
+			return ctrl.Result{}, nil
+		}
+
+		if apierrors.IsNotFound(err) {
+			log.Info("Cluster does not exist yet , waiting until it is created")
+			return ctrl.Result{}, nil
+		}
+
 		log.Error(err, "could not get cluster by machine metadata")
 		return ctrl.Result{}, err
 	}

--- a/controllers/kubeadmconfig_controller_test.go
+++ b/controllers/kubeadmconfig_controller_test.go
@@ -152,9 +152,8 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasBootstrapData(
 	}
 }
 
-// This returns an error since nothing can proceed without an associated cluster.
-// TODO: This should probably not return an error
-func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfMachineDoesNotHaveAssociatedCluster(t *testing.T) {
+// This does not expect an error, hoping the machine gets updated with a cluster
+func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfMachineDoesNotHaveAssociatedCluster(t *testing.T) {
 	machine := newMachine(nil, "machine") // intentionally omitting cluster
 	config := newKubeadmConfig(machine, "cfg")
 
@@ -176,14 +175,13 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfMachineDoesNotHaveAssoci
 		},
 	}
 	_, err := k.Reconcile(request)
-	if err == nil {
-		t.Fatal("Expected error, got nil")
+	if err != nil {
+		t.Fatal("Not Expecting error, got an error")
 	}
 }
 
-// If the associated cluster is not found then there is no way to proceed.
-// TODO: This should probably not be an error
-func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfAssociatedClusterIsNotFound(t *testing.T) {
+// This does not expect an error, hoping that the associated cluster will be created
+func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfAssociatedClusterIsNotFound(t *testing.T) {
 	cluster := newCluster("cluster")
 	machine := newMachine(cluster, "machine")
 	config := newKubeadmConfig(machine, "cfg")
@@ -207,8 +205,8 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfAssociatedClusterIsNotFo
 		},
 	}
 	_, err := k.Reconcile(request)
-	if err == nil {
-		t.Fatal("Expected error, got nil")
+	if err != nil {
+		t.Fatal("Not Expecting error, got an error")
 	}
 }
 


### PR DESCRIPTION
What this PR does / why we need it:
Removes error and waits again if

a) machine does not have any associated cluster
b) Machine has associate cluster but it is still non-existent

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #212