### PR TITLE
🏃Added Test :Return early if the owning machine does not have an associated cluster

### DIFF
--- a/controllers/kubeadmconfig_controller_test.go
+++ b/controllers/kubeadmconfig_controller_test.go
@@ -192,6 +192,34 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasBootstrapData(
 	}
 }
 
+// Return early If the owning machine does not have an associated cluster
+func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasNoCluster(t *testing.T) {
+	machine := newMachine(nil, "machine") // Machine without a cluster
+	config := newKubeadmConfig(machine, "cfg")
+
+	objects := []runtime.Object{
+		machine,
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.Log,
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+	_, err := k.Reconcile(request)
+	if err != nil {
+		t.Fatalf("Not Expecting error, got an error: %+v", err)
+	}
+}
+
 // This does not expect an error, hoping the machine gets updated with a cluster
 func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfMachineDoesNotHaveAssociatedCluster(t *testing.T) {
 	machine := newMachine(nil, "machine") // intentionally omitting cluster


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds a test case  - Return early if the owning machine does not have an associated cluster.

**Which issue(s) this PR fixes**  :
Ref #214 
