### PR TITLE
set init lock's owner as the holding machine

### DIFF
--- a/internal/locking/control_plane_init_mutex.go
+++ b/internal/locking/control_plane_init_mutex.go
@@ -76,7 +76,7 @@ func (c *ControlPlaneInitMutex) Lock(ctx context.Context, cluster *clusterv1.Clu
 	}
 
 	// Adds owner reference, namespace and name
-	sema.setMetadata(cluster)
+	sema.setMetadata(cluster, machine)
 	// Adds the additional information
 	if err := sema.setInformation(&information{MachineName: machine.Name}); err != nil {
 		log.Error(err, "Failed to acquire lock while setting semaphore information")
@@ -159,16 +159,16 @@ func (s semaphore) setInformation(information *information) error {
 	return nil
 }
 
-func (s *semaphore) setMetadata(cluster *clusterv1.Cluster) {
+func (s *semaphore) setMetadata(cluster *clusterv1.Cluster, machine *clusterv1.Machine) {
 	s.ObjectMeta = metav1.ObjectMeta{
 		Namespace: cluster.Namespace,
 		Name:      configMapName(cluster.Name),
 		OwnerReferences: []metav1.OwnerReference{
 			{
-				APIVersion: cluster.APIVersion,
-				Kind:       cluster.Kind,
-				Name:       cluster.Name,
-				UID:        cluster.UID,
+				APIVersion: machine.APIVersion,
+				Kind:       machine.Kind,
+				Name:       machine.Name,
+				UID:        machine.UID,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: JunLi <lijun.git@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Since the init lock holds information about the owner machine, it is better to set the configmap's OwnerReference as the holding machine. Then the configmap can be automatically deleted when we delete the owner machine.

