### PR TITLE
Patch kubeadmconfig objects only if no error occurs during reconciliation

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -151,12 +151,11 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	// Always attempt to Patch the KubeadmConfig object and status after each reconciliation.
+	// Attempt to Patch the KubeadmConfig object and status after each reconciliation if no error occurs.
 	defer func() {
-		if err := patchHelper.Patch(ctx, config); err != nil {
-			log.Error(err, "failed to patch config")
-			if rerr == nil {
-				rerr = err
+		if rerr == nil {
+			if rerr = patchHelper.Patch(ctx, config); rerr != nil {
+				log.Error(rerr, "failed to patch config")
 			}
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: JunLi <lijun.git@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
There is no need to update KubeadmConfig objects if any error occurs during the reconciliation.

