### PR TITLE
🐛 Refresh token for provisioning machines

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,13 @@ func main() {
 		"The minimum interval at which watched resources are reconciled (e.g. 10m)",
 	)
 
+	flag.DurationVar(
+		&controllers.DefaultTokenTTL,
+		"bootstrap-token-ttl",
+		15*time.Minute,
+		"The amount of time the bootstrap token will be valid",
+	)
+
 	flag.StringVar(
 		&watchNamespace,
 		"namespace",
@@ -87,6 +94,10 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(klogr.New())
+
+	if controllers.DefaultTokenTTL-syncPeriod < 1*time.Minute {
+		setupLog.Info("warning: the sync interval is close to the configured token TTL, tokens may expire temporarily before being refreshed")
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Refreshes the token for a machine that's not used it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #248 
