### PR TITLE
✨ Adds support for external etcd & respects custom certificates directory from kubeadm

### DIFF
--- a/cloudinit/cloudinit_test.go
+++ b/cloudinit/cloudinit_test.go
@@ -46,7 +46,7 @@ func TestNewInitControlPlaneAdditionalFileEncodings(t *testing.T) {
 			Users:      nil,
 			NTP:        nil,
 		},
-		Certificates:         cluster.NewCertificates(),
+		Certificates:         cluster.Certificates{},
 		ClusterConfiguration: "my-cluster-config",
 		InitConfiguration:    "my-init-config",
 	}

--- a/cloudinit/controlplane_init.go
+++ b/cloudinit/controlplane_init.go
@@ -52,10 +52,6 @@ type ControlPlaneInput struct {
 // NewInitControlPlane returns the user data string to be used on a controlplane instance.
 func NewInitControlPlane(input *ControlPlaneInput) ([]byte, error) {
 	input.Header = cloudConfigHeader
-	if err := input.Certificates.EnsureAllExist(); err != nil {
-		return nil, err
-	}
-
 	input.WriteFiles = input.Certificates.AsFiles()
 	input.WriteFiles = append(input.WriteFiles, input.AdditionalFiles...)
 	userData, err := generate("InitControlplane", controlPlaneCloudInit, input)

--- a/cloudinit/controlplane_join.go
+++ b/cloudinit/controlplane_join.go
@@ -50,10 +50,7 @@ type ControlPlaneJoinInput struct {
 // NewJoinControlPlane returns the user data string to be used on a new control plane instance.
 func NewJoinControlPlane(input *ControlPlaneJoinInput) ([]byte, error) {
 	input.Header = cloudConfigHeader
-	if err := input.Certificates.EnsureAllExist(); err != nil {
-		return nil, err
-	}
-
+	// TODO: Consider validating that the correct certificates exist. It is different for external/stacked etcd
 	input.WriteFiles = input.Certificates.AsFiles()
 	input.WriteFiles = append(input.WriteFiles, input.AdditionalFiles...)
 	userData, err := generate("JoinControlplane", controlPlaneJoinCloudInit, input)

--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -227,7 +227,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 			return ctrl.Result{}, err
 		}
 
-		certificates := internalcluster.NewCertificates()
+		certificates := internalcluster.NewCertificatesForControlPlane(config.Spec.ClusterConfiguration)
 		if err := certificates.LookupOrGenerate(ctx, r.Client, cluster, config); err != nil {
 			log.Error(err, "unable to lookup or create cluster certificates")
 			return ctrl.Result{}, err
@@ -271,7 +271,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 		}
 	}
 
-	certificates := internalcluster.NewCertificates()
+	certificates := internalcluster.NewCertificatesForWorker(config.Spec.JoinConfiguration.CACertPath)
 	if err := certificates.Lookup(ctx, r.Client, cluster); err != nil {
 		log.Error(err, "unable to lookup cluster certificates")
 		return ctrl.Result{}, err

--- a/controllers/kubeadmconfig_controller_test.go
+++ b/controllers/kubeadmconfig_controller_test.go
@@ -1267,7 +1267,10 @@ func newControlPlaneInitKubeadmConfig(machine *clusterv1.Machine, name string) *
 
 func createSecrets(t *testing.T, cluster *clusterv1.Cluster, owner *bootstrapv1.KubeadmConfig) []runtime.Object {
 	out := []runtime.Object{}
-	certificates := internalcluster.NewCertificates()
+	if owner.Spec.ClusterConfiguration == nil {
+		owner.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{}
+	}
+	certificates := internalcluster.NewCertificatesForControlPlane(owner.Spec.ClusterConfiguration)
 	if err := certificates.Generate(); err != nil {
 		t.Fatal(err)
 	}

--- a/docs/external-etcd.md
+++ b/docs/external-etcd.md
@@ -1,0 +1,77 @@
+# Support for external etcd
+
+Cluster API Bootstrap Provider Kubeadm  supports using an external etcd cluster for your workload Kubernetes clusters.
+
+### ⚠️ Warnings ⚠️
+
+Before getting started you should be aware of the expectations that come with using an external etcd cluster.
+
+* Cluster API is unable to manage any aspect of the external etcd cluster.
+* Depending on how you configure your etcd nodes you may incur additional cloud costs in data transfer.
+    * As an example, cross availability zone traffic can cost money on cloud providers. You don't have to deploy etcd
+    across availability zones, but if you do please be aware of the costs.
+
+### Getting started
+
+To use this, you will need to create an etcd cluster and generate an apiserver-etcd-client key/pair.
+[`etcdadm`](https://github.com/kubernetes-sigs/etcdadm) is a good way to get started if you'd like to test this
+behavior.
+
+Once you create an etcd cluster, you will want to base64 encode the `/etc/etcd/pki/apiserver-etcd-client.crt`,
+`/etc/etcd/pki/apiserver-etcd-client.key`, and `/etc/etcd/pki/server.crt` files and put them in two secrets. The secrets
+must be formatted as follows and the cert material must be base64 encoded:
+
+```yaml
+# Kubernetes APIServer etcd client certificate
+kind: Secret
+apiVersion: v1
+metadata:
+  name: $CLUSTER_NAME-apiserver-etcd-client
+  namespace: $CLUSTER_NAMESPACE
+data:
+  tls.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCRENDQWV5Z0F3SUJBZ0lJZFlkclZUMzV0
+    NW93RFFZSktvWklodmNOQVFFTEJRQXdEekVOTUFzR0ExVUUKQXhNRVpYUmpaREFlRncweE9UQTVN
+    ...
+  tls.key: |
+    LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdlFlTzVKOE5j
+    VCtDeGRubFR3alpuQ3YwRzByY0tETklhZzlSdFdrZ1p4MEcxVm1yClA4Zy9BRkhXVHdxSTUrNi81
+    ...
+```
+
+```yaml
+# Etcd's CA crt file to validate the generated client certificates
+kind: Secret
+apiVersion: v1
+metadata:
+  name: $CLUSTER_NAME-etcd
+  namespace: $CLUSTER_NAMESPACE
+data:
+  tls.crt: |
+    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURBRENDQWVpZ0F3SUJBZ0lJRDNrVVczaDIy
+    K013RFFZSktvWklodmNOQVFFTEJRQXdEekVOTUFzR0ExVUUKQXhNRVpYUmpaREFlRncweE9UQTVN
+    ...
+```
+
+After that the rest is standard Kubeadm. Config your ClusterConfiguration as follows:
+
+```yaml
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: KubeadmConfig
+metadata:
+  name: CLUSTER_NAME-controlplane-0
+  namespace: CLUSTER_NAMESPACE
+spec:
+  ... # initConfiguration goes here
+  clusterConfiguration:
+    etcd:
+      external:
+        endpoints:
+          - https://10.0.0.230:2379
+        caFile: /etc/kubernetes/pki/etcd/ca.crt
+        certFile: /etc/kubernetes/pki/apiserver-etcd-client.crt
+        keyFile: /etc/kubernetes/pki/apiserver-etcd-client.key
+    ... # other clusterConfiguration goes here
+```
+
+Create your cluster as normal!

--- a/internal/cluster/certificates_test.go
+++ b/internal/cluster/certificates_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm/kubeadm/v1beta1"
+)
+
+func TestNewCertificatesForControlPlane_Stacked(t *testing.T) {
+	config := &v1beta1.ClusterConfiguration{}
+	certs := NewCertificatesForControlPlane(config)
+	if certs.GetByPurpose(EtcdCA).KeyFile == "" {
+		t.Fatal("stacked control planes must define etcd CA key file")
+	}
+}
+
+func TestNewCertificatesForControlPlane_External(t *testing.T) {
+	config := &v1beta1.ClusterConfiguration{
+		Etcd: v1beta1.Etcd{
+			External: &v1beta1.ExternalEtcd{},
+		},
+	}
+
+	certs := NewCertificatesForControlPlane(config)
+	if certs.GetByPurpose(EtcdCA).KeyFile != "" {
+		t.Fatal("control planes with external etcd must *not* define the etcd key file")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds additional support + documentation for creating kubernetes clusters that use external etcd.

cc @rbankston

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59
Fixes #255 
