### PR TITLE
🐛 Separate certificate logic for joins

### DIFF
--- a/internal/cluster/certificates.go
+++ b/internal/cluster/certificates.go
@@ -74,8 +74,8 @@ var (
 // Certificates are the certificates necessary to bootstrap a cluster.
 type Certificates []*Certificate
 
-// NewCertificatesForControlPlane returns a list of certificates configured for a control plane node
-func NewCertificatesForControlPlane(config *v1beta1.ClusterConfiguration) Certificates {
+// NewCertificatesForInitialControlPlane returns a list of certificates configured for a control plane node
+func NewCertificatesForInitialControlPlane(config *v1beta1.ClusterConfiguration) Certificates {
 	if config.CertificatesDir == "" {
 		config.CertificatesDir = defaultCertificatesDir
 	}
@@ -120,6 +120,32 @@ func NewCertificatesForControlPlane(config *v1beta1.ClusterConfiguration) Certif
 
 	certificates = append(certificates, etcdCert)
 	return certificates
+}
+
+// NewCertificatesForJoiningControlPlane gets any certs that exist and writes them to disk
+func NewCertificatesForJoiningControlPlane() Certificates {
+	return Certificates{
+		&Certificate{
+			Purpose:  secret.ClusterCA,
+			CertFile: filepath.Join(defaultCertificatesDir, "ca.crt"),
+			KeyFile:  filepath.Join(defaultCertificatesDir, "ca.key"),
+		},
+		&Certificate{
+			Purpose:  ServiceAccount,
+			CertFile: filepath.Join(defaultCertificatesDir, "sa.pub"),
+			KeyFile:  filepath.Join(defaultCertificatesDir, "sa.key"),
+		},
+		&Certificate{
+			Purpose:  FrontProxyCA,
+			CertFile: filepath.Join(defaultCertificatesDir, "front-proxy-ca.crt"),
+			KeyFile:  filepath.Join(defaultCertificatesDir, "front-proxy-ca.key"),
+		},
+		&Certificate{
+			Purpose:  EtcdCA,
+			CertFile: filepath.Join(defaultCertificatesDir, "etcd", "ca.crt"),
+			KeyFile:  filepath.Join(defaultCertificatesDir, "etcd", "ca.key"),
+		},
+	}
 }
 
 // NewCertificatesForWorker return an initialized but empty set of CA certificates needed to bootstrap a cluster.

--- a/internal/cluster/certificates_test.go
+++ b/internal/cluster/certificates_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNewCertificatesForControlPlane_Stacked(t *testing.T) {
 	config := &v1beta1.ClusterConfiguration{}
-	certs := NewCertificatesForControlPlane(config)
+	certs := NewCertificatesForInitialControlPlane(config)
 	if certs.GetByPurpose(EtcdCA).KeyFile == "" {
 		t.Fatal("stacked control planes must define etcd CA key file")
 	}
@@ -37,7 +37,7 @@ func TestNewCertificatesForControlPlane_External(t *testing.T) {
 		},
 	}
 
-	certs := NewCertificatesForControlPlane(config)
+	certs := NewCertificatesForInitialControlPlane(config)
 	if certs.GetByPurpose(EtcdCA).KeyFile != "" {
 		t.Fatal("control planes with external etcd must *not* define the etcd key file")
 	}


### PR DESCRIPTION
With the introduction of support for external etcd comes better
certificate management. This commit separates the worker join certificate
logic from the control plane join certificate logic.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR fixes the bug where control-planes could not join a cluster but were still provisioned.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #262 

/cc @vincepri 
