### PR TITLE
fix: ensure there's a token to refresh

### DIFF
--- a/controllers/kubeadmconfig_controller.go
+++ b/controllers/kubeadmconfig_controller.go
@@ -148,7 +148,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 		err = patchHelper.Patch(ctx, config)
 		return ctrl.Result{}, err
 	// If we've already embedded a time-limited join token into a config, but are still waiting for the token to be used, refresh it
-	case config.Status.Ready:
+	case config.Status.Ready && (config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil):
 		token := config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token
 
 		// gets the remote secret interface client for the current cluster

--- a/controllers/kubeadmconfig_controller_test.go
+++ b/controllers/kubeadmconfig_controller_test.go
@@ -398,7 +398,13 @@ func TestKubeadmConfigReconciler_Reconcile_GenerateCloudConfigData(t *testing.T)
 		t.Fatal("Expected status ready")
 	}
 	if cfg.Status.BootstrapData == nil {
-		t.Fatal("Expected status ready")
+		t.Fatal("Expected generated bootstrap data")
+	}
+
+	// Ensure that we don't fail trying to refresh any bootstrap tokens
+	_, err = k.Reconcile(request)
+	if err != nil {
+		t.Fatalf("Failed to reconcile:\n %+v", err)
 	}
 }
 


### PR DESCRIPTION
For init configurations or non-BootstrapToken discovery mechanisms, we
shouldn't be trying to refresh tokens.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Fixes a panic reconciling kubeadm configs for a control plane init before the control plane is marked as "ready"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #266 
