### PR TITLE
 🐛 Fixes an issue where KubeadmConfig Pre/PostKubeadmCommands were not being properly escaped 

### DIFF
--- a/cloudinit/commands.go
+++ b/cloudinit/commands.go
@@ -19,7 +19,7 @@ package cloudinit
 const (
 	commandsTemplate = `{{- define "commands" -}}
 {{ range . }}
-  - '{{.}}'
+  - {{printf "%q" .}}
 {{- end -}}
 {{- end -}}
 `


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Removes the commands single quote and formats it with `%q`

**Which issue(s) this PR fixes** :
Fixes #192 
