### PR TITLE
🏃 Let GCB build release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,6 @@ $(RELEASE_DIR):
 .PHONY: release
 release: clean-release  ## Builds and push container images using the latest git tag for the commit.
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
-	# Push the release image to the staging bucket first.
-	REGISTRY=$(STAGING_REGISTRY) TAG=$(RELEASE_TAG) \
-		$(MAKE) docker-build-all docker-push-all
 	# Set the manifest image to the production bucket.
 	MANIFEST_IMG=$(PROD_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
 		$(MAKE) set-manifest-image

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,15 +1,13 @@
 # How to release this project
 
-0. Make sure the manger image patch is pointed to the image tag you will be releasing.
-    0. If it is not, update it and open a PR. This is the commit you will use to release.
-1. `git pull` to get the latest merge commit.
-1. Tag the merge commit.
-1. Push the tag.
-2. GithubActions take over from here.
-3. Update the release notes.
-4. Send notifications to relevant slack channels and mailing lists.
-
-## Expected artifacts
-
-1. A release with no binaries.
-2. A container image pushed to the staging bucket tagged with the released version.
+1. Create an annotated tag `git tag -a v0.x.y -m v0.x.y`
+    1. To use your GPG signature when pushing the tag, use `git tag -s [...]` instead
+1. Push the tag to the GitHub repository `git push origin v0.x.y`
+    1. NB: `origin` should be the name of the remote pointing to
+       `github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm`
+1. Run `make release` to build artifacts (the image is automatically built by CI)
+1. Follow the [Image Promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter) to
+   promote the image from the staging repo to `us.gcr.io/k8s-artifacts-prod/capi-kubeadm`
+1. Create a release in GitHub based on the tag created above
+    1. Attach `out/bootstrap-components.yaml` to the release
+1. Send notifications to the relevant Slack channels and mailing lists


### PR DESCRIPTION
**What this PR does / why we need it**:
test-infra has been updated to use GCB to build release version images,
so we no longer need to do it here in the repo.

Requires https://github.com/kubernetes/test-infra/pull/15624

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
