### PR TITLE
✨ import and enable pprof

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ issues:
   # List of regexps of issue texts to exclude, empty list by default.
   exclude:
     - Using the variable on range scope `tc` in function literal
+    - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
 run:
   deadline: 2m
   skip-dirs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Following up on this [PR](https://github.com/kubernetes-sigs/cluster-api/pull/2084). Adding `pprof` to this repo. 

