### PR TITLE
🐛 passwd field is omitempty because it's optional

### DIFF
--- a/api/v1alpha2/kubeadmbootstrapconfig_types.go
+++ b/api/v1alpha2/kubeadmbootstrapconfig_types.go
@@ -168,7 +168,7 @@ type User struct {
 
 	// Passwd specifies a hashed password for the user
 	// +optional
-	Passwd *string `json:"passwd"`
+	Passwd *string `json:"passwd,omitempty"`
 
 	// PrimaryGroup specifies the primary group for the user
 	// +optional


### PR DESCRIPTION


**What this PR does / why we need it**:
- add `omitempty` to the `passwd` field since its optional 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #291 
