### PR TITLE
📖  use k8s-staging-ci-images vs kubernetes-ci-images

### DIFF
--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -268,7 +268,7 @@ spec:
                   description: ImageRepository sets the container registry to pull
                     images from. If empty, `k8s.gcr.io` will be used by default; in
                     case of kubernetes version is a CI build (kubernetes version starts
-                    with `ci/` or `ci-cross/`) `gcr.io/kubernetes-ci-images` will
+                    with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will
                     be used as a default for control plane components and for kube-proxy,
                     while `k8s.gcr.io` will be used for all the other images.
                   type: string

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -286,7 +286,7 @@ spec:
                             to pull images from. If empty, `k8s.gcr.io` will be used
                             by default; in case of kubernetes version is a CI build
                             (kubernetes version starts with `ci/` or `ci-cross/`)
-                            `gcr.io/kubernetes-ci-images` will be used as a default
+                            `gcr.io/k8s-staging-ci-images` will be used as a default
                             for control plane components and for kube-proxy, while
                             `k8s.gcr.io` will be used for all the other images.
                           type: string

--- a/kubeadm/v1beta1/types.go
+++ b/kubeadm/v1beta1/types.go
@@ -116,7 +116,7 @@ type ClusterConfiguration struct {
 
 	// ImageRepository sets the container registry to pull images from.
 	// If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
-	// `gcr.io/kubernetes-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+	// `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
 	// will be used for all the other images.
 	// +optional
 	ImageRepository string `json:"imageRepository,omitempty"`

--- a/kubeadm/v1beta2/types.go
+++ b/kubeadm/v1beta2/types.go
@@ -97,7 +97,7 @@ type ClusterConfiguration struct {
 
 	// ImageRepository sets the container registry to pull images from.
 	// If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
-	// `gcr.io/kubernetes-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+	// `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
 	// will be used for all the other images.
 	ImageRepository string `json:"imageRepository,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Document that the default CI images are pulled from
gcr.io/k8s-staging-ci-images, not gcr.io/kubernetes-ci-images

This was changed via https://github.com/kubernetes/kubernetes/pull/97087
which landed 2021-01-14

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

Related:
- This is part of https://github.com/kubernetes/k8s.io/issues/2318
- More specifically https://github.com/kubernetes/k8s.io/issues/1460